### PR TITLE
feat: add repeatable installer and versioned release downloads

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
       - run: uv run --locked ruff check src tests scripts
       - run: uv run --locked ruff format --check src tests scripts
       - run: uv run --locked ty check src tests scripts
+      - run: bash -n install.sh
       - run: uv run --locked pytest
 
   web:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,12 +52,30 @@ jobs:
           uv lock --check
           uv build --clear
 
+      - name: Prepare release downloads
+        run: |
+          mkdir -p release
+          cp dist/*.whl dist/*.tar.gz install.sh release/
+          cd release
+          sha256sum ./*.whl ./*.tar.gz install.sh > SHA256SUMS
+
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: blocksd-distributions
+          path: release/
+          if-no-files-found: error
+
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # release/v1
 
   github-release:
     uses: hyperb1iss/shared-workflows/.github/workflows/github-release.yml@9edda2222785fe0351a26a07bf26a3385874d288 # v1
     needs: [pypi]
+    with:
+      attach-artifacts: true
+      artifact-pattern: blocksd-distributions
+      release-notes-provider: anthropic
+      release-notes-model: claude-opus-5
     permissions:
       contents: write
       actions: read

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,10 @@
-# blocksd — ROLI Blocks Linux Daemon
+# blocksd: ROLI Blocks Linux Daemon
 
 ## Project Overview
 
-Linux daemon that implements the ROLI Blocks protocol to keep devices alive, control LEDs, and manage topology. ROLI devices require an active host-side handshake over MIDI SysEx to enter "API mode" — without it, they show a "searching" animation and eventually power off.
+Linux daemon that implements the ROLI Blocks protocol to keep devices alive, control LEDs, and manage topology. ROLI devices require an active host-side handshake over MIDI SysEx to enter "API mode": without it, they show a "searching" animation and eventually power off.
 
-**Stack:** Python 3.13, asyncio, python-rtmidi, Typer, Rich, Pydantic
+**Stack:** Python 3.13+, asyncio, python-rtmidi, Typer, Rich, Pydantic
 **Package Manager:** uv
 **Linter:** ruff
 **Type Checker:** ty
@@ -88,7 +88,7 @@ TOPOLOGY_INDEX_BROADCAST = 63
 API_MODE_PING_TIMEOUT_MS = 5000
 ```
 
-### Message Types — Device → Host
+### Message Types: Device → Host
 
 | ID     | Name                   | Payload                                         |
 | ------ | ---------------------- | ----------------------------------------------- |
@@ -111,7 +111,7 @@ API_MODE_PING_TIMEOUT_MS = 5000
 | `0x28` | programEventMessage    | 3 × 32b integers                                |
 | `0x30` | logMessage             | string data                                     |
 
-### Message Types — Host → Device
+### Message Types: Host → Device
 
 | ID     | Name                 | Payload                            |
 | ------ | -------------------- | ---------------------------------- |
@@ -154,8 +154,8 @@ API_MODE_PING_TIMEOUT_MS = 5000
 
 | ID  | Name                     | Extra bits                  |
 | --- | ------------------------ | --------------------------- |
-| `0` | endOfPacket              | —                           |
-| `1` | endOfChanges             | —                           |
+| `0` | endOfPacket              | :                           |
+| `1` | endOfChanges             | :                           |
 | `2` | skipBytesFew             | 4b count                    |
 | `3` | skipBytesMany            | 8b count                    |
 | `4` | setSequenceOfBytes       | (8b value + 1b continues)×N |
@@ -247,59 +247,39 @@ Max 6 devices and 24 connections per topology packet. Use extend/end for larger 
 
 Protocol source (cloned to `~/Downloads/roli-extracted/roli_blocks_basics/`):
 
-- `protocol/roli_BitPackingUtilities.h` — 7-bit packing algorithm (CRITICAL to port correctly)
-- `protocol/roli_BlocksProtocolDefinitions.h` — all enums, constants, bit sizes
-- `protocol/roli_HostPacketBuilder.h` — host→device packet construction
-- `protocol/roli_HostPacketDecoder.h` — device→host packet parsing
-- `protocol/roli_BlockModels.h` — device type definitions and capabilities
-- `topology/internal/roli_ConnectedDeviceGroup.cpp` — full device lifecycle state machine
-- `topology/internal/roli_BlockSerialReader.cpp` — serial number request/parse
-- `topology/internal/roli_MIDIDeviceDetector.cpp` — MIDI port scanning/matching
-- `topology/internal/roli_Detector.cpp` — top-level detection loop
-- `topology/internal/roli_MidiDeviceConnection.cpp` — MIDI I/O wrapper
+- `protocol/roli_BitPackingUtilities.h`: 7-bit packing algorithm (CRITICAL to port correctly)
+- `protocol/roli_BlocksProtocolDefinitions.h`: all enums, constants, bit sizes
+- `protocol/roli_HostPacketBuilder.h`: host→device packet construction
+- `protocol/roli_HostPacketDecoder.h`: device→host packet parsing
+- `protocol/roli_BlockModels.h`: device type definitions and capabilities
+- `topology/internal/roli_ConnectedDeviceGroup.cpp`: full device lifecycle state machine
+- `topology/internal/roli_BlockSerialReader.cpp`: serial number request/parse
+- `topology/internal/roli_MIDIDeviceDetector.cpp`: MIDI port scanning/matching
+- `topology/internal/roli_Detector.cpp`: top-level detection loop
+- `topology/internal/roli_MidiDeviceConnection.cpp`: MIDI I/O wrapper
 
 Extracted ROLI Connect installer (`~/Downloads/roli-extracted/`):
 
-- `rpkg-driver/` — Windows driver package (reference only)
-- `midi-driver/DriverINF` — USB VID/PID mapping
-- `app-asar-unpacked/` — Electron app source (minified JS)
-- `app/resources/app/resources/extra/firmware/default/*.littlefoot` — device firmware
+- `rpkg-driver/`: Windows driver package (reference only)
+- `midi-driver/DriverINF`: USB VID/PID mapping
+- `app-asar-unpacked/`: Electron app source (minified JS)
+- `app/resources/app/resources/extra/firmware/default/*.littlefoot`: device firmware
 
-## Implementation Phases
+## Current Implementation and Checks
 
-### Phase 1: Protocol Core (no hardware needed)
+Protocol, device, topology, daemon, API, CLI, and dashboard layers are implemented. API transports share validation in `api/commands.py`; each server owns its subscriptions and brightness state. The daemon owns background task shutdown and partial-startup cleanup.
 
-`protocol/constants.py` → `protocol/checksum.py` → `protocol/packing.py` → `protocol/builder.py` → `protocol/decoder.py` → `protocol/serial.py` + full test suite
+CLI commands live in `cli/app.py`, `cli/led.py`, `cli/config.py`, and `cli/install.py`. LED/config commands open independent MIDI sessions; they are not socket clients. Stop the service before running them.
 
-### Phase 2: Device Models
+LittleFoot program upload is disabled, including the unreachable unrolled fill fallback. Accepted LED frames confirm heap writes, not visible rendering. Config timing fields are not forwarded to the runtime.
 
-`device/models.py` → `device/registry.py` → `device/config_ids.py`
-
-### Phase 3: Connection Layer
-
-`device/connection.py` → `topology/detector.py` → `topology/device_group.py` → `topology/manager.py`
-
-### Phase 4: Daemon + Config
-
-`daemon.py` → `config/schema.py` + `config/loader.py` → `logging.py`
-
-### Phase 5: CLI
-
-`cli/app.py` → `cli/status.py` → `cli/config_cmd.py` → `cli/led_cmd.py`
-
-### Phase 6: LED Control + Program Upload
-
-`led/bitmap.py` → `led/patterns.py` → `protocol/data_change.py`
-
-### Phase 7: Polish
-
-systemd service → udev rules → `cli/service.py` → sd_notify integration
+Use `just install` for locked Python, dashboard, and documentation dependencies. Run `just check` for Python lint/types/tests, dashboard checks, documentation build, and installed-wheel verification. Dashboard and docs use pnpm. See CONTRIBUTING.md for individual commands and release requirements.
 
 ## Critical Implementation Notes
 
-- **7-bit packing is the #1 risk** — must be tested exhaustively with round-trips and golden vectors from the C++ implementation
-- **Ping timing is critical** — 5000ms timeout means we need reliable <400ms ping intervals. Use dedicated asyncio tasks, not shared timers
-- **rtmidi callbacks arrive on a separate thread** — marshal to asyncio via `loop.call_soon_threadsafe()` or `asyncio.Queue`
-- **ALSA handles multi-client MIDI natively** — we don't block DAW access
-- **Device detection**: match MIDI port names containing "BLOCK" or "Block", validate with USB VID `0x2AF4` via sysfs as fallback
+- **7-bit packing is the #1 risk**: must be tested exhaustively with round-trips and golden vectors from the C++ implementation
+- **Ping timing is critical**: 5000ms timeout means we need reliable <400ms ping intervals. Use dedicated asyncio tasks, not shared timers
+- **rtmidi callbacks arrive on a separate thread**: marshal to asyncio via `loop.call_soon_threadsafe()` or `asyncio.Queue`
+- **ALSA handles multi-client MIDI natively**: we don't block DAW access
+- **Device detection**: match MIDI port names containing "BLOCK" or "Block" and pair normalized input/output names; no sysfs fallback exists
 - **Incoming packet processing**: strip SysEx header (5 bytes), first byte after header is device index, remaining bytes are payload + checksum (last byte). Validate checksum on payload bytes, then create `Packed7BitReader` from payload (excluding checksum)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ just docs-build         # documentation production build
 just build-check        # build and verify the installed distribution
 ```
 
-Run the daemon in a separate terminal for dashboard development:
+Stop any installed blocksd service before starting a development daemon. Run the daemon in a separate terminal for dashboard development:
 
 ```bash
 uv run --locked blocksd ui --no-browser
@@ -47,6 +47,8 @@ The live daemon controls connected hardware. The Python test suite uses simulate
 The source of truth for Python tool versions is `uv.lock`, including the local Ruff hooks. Installs and checks use locked resolution so a stale manifest fails visibly. JavaScript installs use `--frozen-lockfile`. These follow the [uv locking model](https://docs.astral.sh/uv/concepts/projects/sync/) and each project's committed pnpm lockfile.
 
 Use `just fix` for Python lint fixes and formatting, `pnpm --dir web format` for the dashboard, and `just fmt-docs` for documentation. Formatting is explicit; normal checks do not rewrite source.
+
+The LED and config CLI commands currently open their own MIDI sessions. The daemon skips LittleFoot renderer upload, so tests of frame acceptance do not establish visible LED output. Timing fields in DaemonConfig are parsed but not forwarded to the topology runtime. Keep documentation and release notes explicit about these limitations.
 
 ## Architecture
 
@@ -89,3 +91,9 @@ pnpm --dir docs audit
 The docs site pins VitePress to an explicit prerelease while that supported dependency graph is needed. Review its release notes and build the site before changing the pin. Dependabot proposes weekly Python, JavaScript and GitHub Actions updates; action references use commit SHAs.
 
 Keep commits focused, include regression tests for behavior changes, and document any hardware verification separately from automated test results.
+
+## Releases
+
+Run `just check`, merge the changes, then dispatch Release with an explicit version (for example, `0.5.0`). Use its `dry_run` option to exercise preparation without tagging or publishing. The publication workflow generates release notes with git-iris using the Anthropic provider and `claude-opus-5`. Review the generated notes for accurate upgrade instructions and hardware limitations.
+
+The release workflow updates package metadata, builds and verifies distributions, creates a tag, and dispatches publication. The GitHub release includes the wheel, source archive, `install.sh`, and `SHA256SUMS`; PyPI publication uses trusted publishing. Check the release and publish workflow results before announcing availability. The latest installer URL follows the latest GitHub release, while `--version` selects the package version from PyPI.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@
 
 ROLI Blocks devices need an active host-side handshake over MIDI SysEx to enter "API mode." Without it, they show a searching animation and eventually power off. There's no official Linux support.
 
-**blocksd** implements the full ROLI Blocks protocol: device discovery, topology management, API mode keepalive, LED control, touch events, and device configuration. Your Blocks stay alive and useful on Linux.
+**blocksd** implements the ROLI Blocks host protocol: device discovery, topology management, API mode keepalive, LED control, touch events, and device configuration. Your Blocks stay alive and useful on Linux.
 
 ## ✦ Features
 
@@ -44,7 +44,7 @@ ROLI Blocks devices need an active host-side handshake over MIDI SysEx to enter 
 | 💡 **LED Control**           | Lightpad / Lightpad M RGB565 bitmap grid, CLI patterns (solid, gradient, rainbow, checkerboard) |
 | 👆 **Touch & Button Events** | Normalized touch data (x/y/z/velocity) and button callbacks                                     |
 | ⚙️ **Device Config**         | Read/write device settings (sensitivity, MIDI channel, scale, etc.)                             |
-| 🔊 **DAW Friendly**          | ALSA multi-client, blocksd and your DAW share MIDI without conflict                            |
+| 🔊 **DAW Friendly**          | ALSA multi-client, blocksd and your DAW share MIDI without conflict                             |
 | 🛡️ **systemd Integration**   | Type=notify service, watchdog heartbeat, udev rules for plug-and-play                           |
 
 ## 📦 Install
@@ -52,32 +52,31 @@ ROLI Blocks devices need an active host-side handshake over MIDI SysEx to enter 
 ### Quick Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/hyperb1iss/blocksd/main/install.sh | bash
+curl -fsSL https://github.com/hyperb1iss/blocksd/releases/latest/download/install.sh -o install-blocksd.sh
+bash install-blocksd.sh
 ```
 
-Installs blocksd, udev rules, and a systemd user service in one shot.
+Installs or upgrades blocksd using uv and managed Python, installs udev rules with sudo, and enables and restarts a systemd user service. Run as your normal user. Use `--version 0.5.0` to select a release or `--no-udev`, `--no-service`, and `--no-enable` to skip setup steps. See the [installation guide](https://hyperb1iss.github.io/blocksd/guide/installation) for prerequisites and upgrade details.
 
 ### From PyPI
 
 ```bash
-uv tool install blocksd
+uv tool install --python 3.13 blocksd
 blocksd install    # sets up systemd service + udev rules
 ```
 
-### Arch Linux (AUR)
+### Arch Linux
 
-```bash
-yay -S blocksd       # stable release
-yay -S blocksd-git   # latest from main
-```
+Packaging recipes live in `packaging/aur/`. AUR publication is separate from a GitHub or PyPI release; check the package's availability before installing through an AUR helper.
 
 ### From Source
 
 ```bash
 git clone https://github.com/hyperb1iss/blocksd.git
 cd blocksd
-uv sync
-uv run blocksd install
+just install
+just web-build
+uv run --locked blocksd install
 ```
 
 The `install` command sets up:
@@ -88,10 +87,13 @@ The `install` command sets up:
 
 ## ⚡ Usage
 
+The current daemon does not upload its LittleFoot LED renderer (firmware opcode compatibility remains unresolved). LED commands and API frames can update heap data, but an accepted write does not establish visible LED output. See the [LittleFoot notes](https://hyperb1iss.github.io/blocksd/architecture/littlefoot).
+
 ### Running the Daemon
 
 ```bash
 # Foreground with verbose logging
+systemctl --user stop blocksd   # if the service is installed
 blocksd run -v
 
 # As a systemd service (after install)
@@ -117,19 +119,23 @@ INFO  ✨ Device connected: lightpad_block_m (LPMJW6SWHSPD8H92), battery 31%
 blocksd status
 
 # Full probe, connects to devices, shows type/serial/battery/version
+systemctl --user stop blocksd   # also stop any foreground daemon
 blocksd status --probe
+systemctl --user start blocksd
 ```
 
 ### LED Control
+
+The LED and config commands open their own MIDI sessions. Stop the service and any foreground daemon before using them. LED commands remain running until Ctrl+C; config commands probe for about eight seconds. Restart the service afterward.
 
 Control the 15×15 LED grid on Lightpad Block and Lightpad Block M:
 
 ```bash
 blocksd led solid '#ff00ff'                          # solid color
-blocksd led rainbow                                   # animated rainbow
+blocksd led rainbow                                   # static rainbow
 blocksd led gradient ff0000 0000ff                    # horizontal gradient
 blocksd led gradient ff0000 0000ff --vertical         # vertical gradient
-blocksd led checkerboard ff0000 00ff00                # 2×2 checkerboard
+blocksd led checkerboard ff0000 00ff00                # 1x1 checkerboard
 blocksd led checkerboard ff0000 00ff00 --size 3       # 3×3 checkerboard
 blocksd led off                                       # lights off
 ```
@@ -146,8 +152,10 @@ blocksd config set 10 50               # write velocity sensitivity
 
 ### Web Dashboard
 
+If blocksd is already running, open `http://localhost:9010` directly. Use `blocksd ui` only when no daemon is running; the command starts its own daemon.
+
 ```bash
-blocksd ui                             # launch web UI on http://localhost:9010
+blocksd ui                             # start a daemon and open its dashboard
 blocksd ui --port 8080                 # custom port
 ```
 
@@ -158,8 +166,8 @@ Opens a real-time dashboard showing connected devices, topology, battery status,
 ```bash
 blocksd install                        # install systemd service + udev rules
 blocksd install --no-udev              # skip udev rules
-blocksd install --no-enable            # install but don't auto-start
-blocksd uninstall                      # remove everything
+blocksd install --no-enable            # write/reload without starting or restarting
+blocksd uninstall                      # remove service and udev rules
 ```
 
 ## 🔌 External API
@@ -187,7 +195,7 @@ The quick rules:
   this usually means the device is not ready yet, the `uid` is gone, or the
   payload was malformed
 - Once a device is live, frame writes are coalesced daemon-side to the latest
-  target state instead of surfacing host-visible “busy” backpressure
+  target state instead of surfacing host-visible "busy" backpressure
 - Prefer a separate subscription socket if you also want events; outbound NDJSON
   events and 1-byte binary frame acks share the same connection
 
@@ -222,12 +230,13 @@ blocksd
 ├── littlefoot/
 │   ├── opcodes.py            LittleFoot VM opcode definitions
 │   ├── assembler.py          bytecode assembler with label support
-│   └── programs.py           BitmapLEDProgram (94-byte repaint)
+│   └── programs.py           BitmapLEDProgram (100-byte repaint)
 ├── topology/
 │   ├── detector.py           MIDI port scanning
 │   ├── device_group.py       connection lifecycle (the big one)
 │   └── manager.py            orchestrates DeviceGroups
 ├── api/
+│   ├── commands.py           shared command validation and dispatch
 │   ├── server.py             Unix socket + WebSocket servers
 │   ├── protocol.py           NDJSON + binary frame wire protocol
 │   ├── events.py             event broadcaster (device/touch/button/config)
@@ -271,11 +280,11 @@ Host                                          Device
 | Lightpad Block / M      | `0x0900`            | `LPB` / `LPM` | ✅ Tested   |
 | LUMI Keys Block         | `0x0E00`            | `LKB`         | ✅ Tested   |
 | Seaboard Block          | `0x0700`            | `SBB`         | 🔲 Untested |
-| Live Block              | —                 | `LIC`         | 🔲 Untested |
-| Loop Block              | —                 | `LOC`         | 🔲 Untested |
-| Developer Control Block | —                 | `DCB`         | 🔲 Untested |
-| Touch Block             | —                 | `TCB`         | 🔲 Untested |
-| Seaboard RISE 25/49     | `0x0200` / `0x0210` | —           | 🔲 Untested |
+| Live Block              | Unknown             | `LIC`         | 🔲 Untested |
+| Loop Block              | Unknown             | `LOC`         | 🔲 Untested |
+| Developer Control Block | Unknown             | `DCB`         | 🔲 Untested |
+| Touch Block             | Unknown             | `TCB`         | 🔲 Untested |
+| Seaboard RISE 25/49     | `0x0200` / `0x0210` | N/A           | 🔲 Untested |
 
 Bitmap LED streaming is currently exposed for Lightpad Block / Lightpad Block M
 only. Other devices are still discoverable and supported by the topology/API
@@ -302,8 +311,9 @@ See [VISION.md](VISION.md) for the full vision, use cases, and ideas beyond musi
 - [x] **Topology Management**: multi-device tracking, DNA connections
 - [x] **API Mode Keepalive**: full state machine with correct ping timing
 - [x] **Remote Heap Manager**: ACK tracking, retransmission, heap state sync
-- [x] **LittleFoot Programs**: bytecode assembler, BitmapLEDProgram upload
-- [x] **CLI LED Commands**: `blocksd led solid #ff00ff`, `blocksd led rainbow`
+- [x] **LittleFoot Assembler**: bytecode generation and BitmapLEDProgram definition
+- [ ] **LittleFoot Upload**: firmware-compatible renderer for visible LED output
+- [x] **CLI LED Commands**: `blocksd led solid '#ff00ff'`, `blocksd led rainbow`
 - [x] **Touch/Button Events**: normalized callbacks with full velocity data
 - [x] **Config Commands**: read/write device settings via CLI
 - [x] **sd_notify Integration**: Type=notify service with watchdog heartbeat

--- a/VISION.md
+++ b/VISION.md
@@ -1,4 +1,4 @@
-# 🔮 blocksd:Vision & Use Cases
+# 🔮 blocksd: Vision & Use Cases
 
 > _These are precision touch surfaces with pressure sensitivity, LED feedback, and mesh networking. Why limit them to music?_
 
@@ -97,6 +97,8 @@ A physical, tactile interface for home automation.
 
 ---
 
+These are proposed applications, not bundled features. The current daemon skips LittleFoot renderer upload, so LED-based ideas depend on resolving firmware compatibility first. Unix socket and WebSocket APIs already provide discovery and event subscriptions.
+
 ## 🧪 Experimental Ideas
 
 ### Multi-Block Configurations
@@ -130,7 +132,7 @@ The devices run LittleFoot, a simple bytecode VM. Programs uploaded to the devic
 
 ### WebSocket / HTTP API
 
-Expose device state and control over HTTP for browser-based interfaces:
+The HTTP dashboard and WebSocket device API exist today. Webhooks, classroom orchestration, and visible LED rendering still need further work:
 
 - **Web dashboard**: real-time device status, battery, topology visualization
 - **Remote LED control**: paint on the grid from a phone browser
@@ -153,7 +155,7 @@ Expose device state and control over HTTP for browser-based interfaces:
 - [x] **systemd/udev**: user service, device rules, install/uninstall CLI
 - [x] **Remote Heap Manager**: ACK-tracked heap state, retransmission, in-flight budgets
 - [x] **LittleFoot Assembler**: bytecode assembler with label resolution and FNV1a function hashing
-- [x] **CLI LED Commands**: `blocksd led solid #ff00ff`, rainbow, gradient, checkerboard
+- [x] **CLI LED Commands**: `blocksd led solid '#ff00ff'`, rainbow, gradient, checkerboard
 - [x] **Touch & Button Events**: normalized pressure/velocity callbacks
 - [x] **Config Commands**: device settings read/write via CLI
 - [x] **sd_notify Integration**: Type=notify service with watchdog heartbeat
@@ -187,12 +189,12 @@ ROLI still actively ships and supports Blocks on Windows and macOS, but Linux ge
 
 blocksd brings full Blocks support to Linux. With a clean protocol implementation and a daemon that handles the lifecycle, these devices become a platform for whatever you can imagine, on the OS of your choice.
 
-The 15×15 LED grid on a Lightpad is small. But it's physical, tactile, and sitting right there on your desk. Sometimes the most useful display isn't the one with the most pixels:it's the one you can reach out and touch.
+The 15×15 LED grid on a Lightpad is small. But it's physical, tactile, and sitting right there on your desk. Sometimes the most useful display isn't the one with the most pixels: it's the one you can reach out and touch.
 
 ---
 
 <div align="center">
 
-_Blocks on Linux:because your OS shouldn't limit your hardware._
+_Blocks on Linux: because your OS shouldn't limit your hardware._
 
 </div>

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -69,7 +69,7 @@ The LED write path is the most performance-sensitive data flow:
 5. **Data change encoding**: the diff is encoded as skip/set/RLE commands
 6. **Packet building**: commands are 7-bit packed into a `sharedDataChange` SysEx packet
 7. **MIDI write**: the packet is sent over USB MIDI
-8. **ACK tracking**: the daemon waits for a `packetACK` before sending the next diff
+8. **ACK tracking**: the daemon waits for a `packetACK` to confirm in-flight packets; multiple packets can be outstanding within the heap manager's budget
 9. **Coalescing**: if new frames arrive while a write is in-flight, the heap manager merges them into the latest target state rather than queuing each frame
 
 ### Frame Coalescing
@@ -84,7 +84,7 @@ graph TD
     DEV -->|ACK| NEXT[Next diff from<br/>current target]
 ```
 
-When the client sends frames faster than the device can accept them, the heap manager doesn't queue them up. It always diffs against the latest target state, which means intermediate frames are automatically skipped. The device always converges to the most recent frame the client sent.
+When the client sends frames faster than the device can accept them, the heap manager doesn't queue them up. It always diffs against the latest target state, which means intermediate frames are automatically skipped. The target heap converges as packets are acknowledged. Visible rendering also requires a compatible LittleFoot program, which the current daemon does not upload.
 
 ## Keepalive Flow
 
@@ -94,11 +94,11 @@ graph LR
     BUILD --> SEND[Send SysEx]
     SEND --> WAIT[Wait for ACK]
     WAIT -->|ACK received| TIMER
-    WAIT -->|5000ms timeout| DEAD[Device Timeout]
+    WAIT -->|6000ms timeout| DEAD[Device Timeout]
     DEAD --> CLEANUP[Remove Device]
 ```
 
-The keepalive ping is a simple `deviceCommandMessage` with command `0x03`. The device must respond with a `packetACK` within 5 seconds or blocksd considers it disconnected.
+The keepalive ping is a simple `deviceCommandMessage` with command `0x03`. The device must respond with a `packetACK` within 6 seconds or blocksd considers it disconnected (the firmware has its own 5-second API mode timeout).
 
 ## Protocol Pipeline Summary
 

--- a/docs/architecture/index.md
+++ b/docs/architecture/index.md
@@ -1,6 +1,6 @@
 # Architecture Overview
 
-blocksd is about 5,700 lines of Python organized into layered modules with strict boundaries. Protocol logic is pure and testable without hardware. Device lifecycle is async and self-healing. The API layer broadcasts events to subscribers without blocking the core loop.
+blocksd is organized into layered modules with strict boundaries. Protocol logic is pure and testable without hardware. Device lifecycle is async and self-healing. The API layer broadcasts events to subscribers without blocking the core loop.
 
 ```mermaid
 graph TB
@@ -33,13 +33,16 @@ graph TB
         LED[LED Bitmap + Patterns]
         LF[LittleFoot Assembler]
     end
-    CLI --> SOCK
+    CLI --> TM
+    SOCK --> CMD[Shared Commands]
+    WSOCK --> CMD
+    CMD --> TM
     WEB --> WSOCK
     SOCK --> EVT
     WSOCK --> EVT
-    EVT --> TM
+    TM --> EVT
     TM --> DG
-    DG --> DET
+    TM --> DET
     DG --> CONN
     CONN --> BUILD
     CONN --> DECODE
@@ -55,25 +58,25 @@ graph TB
 
 ## Design Principles
 
-**Pure protocol, no I/O.** The `protocol/` package contains zero I/O. Packing, checksums, building, and decoding are pure functions that can be tested without hardware. All MIDI I/O lives in `device/connection.py`.
+**Pure protocol, no I/O.** The `protocol/` package contains zero I/O. Packing, checksums, building, and decoding are pure functions that can be tested without hardware. MIDI transport I/O lives in `device/connection.py`; port enumeration lives in `topology/detector.py`.
 
 **One DeviceGroup per USB connection.** Each USB-connected ROLI device gets its own DeviceGroup that manages the full lifecycle: serial request, topology, API activation, keepalive, and cleanup. DNA-connected devices are managed through their master's DeviceGroup.
 
 **asyncio everywhere.** The daemon is single-threaded asyncio. The only thread boundary is the rtmidi callback, which marshals data to the event loop via `call_soon_threadsafe()`.
 
-**Event broadcasting, not polling.** API clients subscribe to event streams (device, touch, button). The EventBroadcaster pushes events to subscribers with bounded queues and automatic cleanup of slow consumers.
+**Event subscriptions.** API clients subscribe to device, touch, button, config, and topology events. The EventBroadcaster pushes events to subscribers with bounded queues and automatic cleanup of slow consumers.
 
 ## Module Map
 
-| Module        | Size | Responsibility                                                                        |
-| ------------- | ---- | ------------------------------------------------------------------------------------- |
-| `protocol/`   | 172K | Pure protocol logic: packing, checksums, builder, decoder, data changes, heap manager |
-| `api/`        | 124K | Unix socket, WebSocket, HTTP servers, event broadcasting                              |
-| `topology/`   | 100K | Device discovery, lifecycle state machine, topology tracking                          |
-| `cli/`        | 76K  | Typer CLI: run, status, led, config, install commands                                 |
-| `littlefoot/` | 64K  | LittleFoot VM bytecode assembler and programs                                         |
-| `device/`     | 48K  | Device models, registry, connection wrapper, config IDs                               |
-| `led/`        | 36K  | RGB565 bitmap grid, LED patterns                                                      |
-| `config/`     | 12K  | Pydantic config schema, TOML loader                                                   |
+| Module        | Responsibility                                                                        |
+| ------------- | ------------------------------------------------------------------------------------- |
+| `protocol/`   | Pure protocol logic: packing, checksums, builder, decoder, data changes, heap manager |
+| `api/`        | Unix socket, WebSocket, HTTP servers, event broadcasting                              |
+| `topology/`   | Device discovery, lifecycle state machine, topology tracking                          |
+| `cli/`        | Typer CLI: run, status, led, config, install commands                                 |
+| `littlefoot/` | LittleFoot VM bytecode assembler and programs                                         |
+| `device/`     | Device models, registry, connection wrapper, config IDs                               |
+| `led/`        | RGB565 bitmap grid, LED patterns                                                      |
+| `config/`     | Pydantic config schema, TOML loader                                                   |
 
 See [Module Structure](./modules) for details on each module.

--- a/docs/architecture/littlefoot.md
+++ b/docs/architecture/littlefoot.md
@@ -1,6 +1,6 @@
 # LittleFoot VM
 
-ROLI Blocks devices run LittleFoot, a bytecode virtual machine baked into the firmware. Programs uploaded to the device execute locally at native speed, enabling LED rendering and touch processing without USB round-trips. This is how ROLI's own software achieves responsive LED feedback: the host writes pixel data to the device heap, and a LittleFoot program reads it and calls `fillPixel()` on each repaint cycle.
+ROLI Blocks devices run LittleFoot, a bytecode virtual machine baked into the firmware. Programs uploaded to the device execute locally in the firmware VM, enabling LED rendering and touch processing without USB round-trips. This is how ROLI's own software achieves responsive LED feedback: the host writes pixel data to the device heap, and a LittleFoot program reads it and calls `fillPixel()` on each repaint cycle.
 
 ## Architecture
 
@@ -43,7 +43,7 @@ These functions are called via the `callNative` opcode with the function's 16-bi
 
 ## BitmapLEDProgram
 
-The primary use case for LittleFoot in blocksd is the BitmapLEDProgram: a 94-byte repaint routine that reads RGB565 pixel data from the heap and calls `fillPixel()` for each of the 225 pixels on the Lightpad's 15x15 grid.
+The primary use case for LittleFoot in blocksd is the BitmapLEDProgram: a 100-byte repaint routine that reads RGB565 pixel data from the heap and calls `fillPixel()` for each of the 225 pixels on the Lightpad's 15x15 grid.
 
 This is the same approach used by the ROLI SDK. The host writes pixel data to the device heap via SharedDataChange, and the LittleFoot program renders it on each repaint cycle.
 
@@ -80,7 +80,7 @@ The firmware's opcode table differs from the ROLI JUCE SDK source. Opcodes `0x11
 
 ### Workaround
 
-blocksd currently bypasses LittleFoot entirely for LED control. Instead of uploading a repaint program and writing pixel data to the heap, the daemon uses unrolled `fillPixel` calls (225 per frame) via SharedDataChange. This is less efficient but works reliably on all tested firmware versions.
+An unrolled `fillPixel` test program exists in the source, but the loader returns before uploading it. The daemon currently uploads neither that fallback nor BitmapLEDProgram. The LED frame API still accepts and transfers RGB565 heap data; a successful frame acknowledgement confirms acceptance by the daemon, not visible rendering. A compatible renderer must be uploaded before heap changes can reliably drive the display.
 
 ## Key Bugs Discovered
 
@@ -94,7 +94,7 @@ Messages addressed to a DNA-connected Lightpad weren't delivered unless the USB-
 
 ### Initial TOS Value
 
-The VM initializes `tos = 0` before calling `repaint()`. The first push operation flushes this value onto the stack, creating an extra entry that shifts all `dup_offset` references. Worked around with unrolled code.
+The VM initializes `tos = 0` before calling `repaint()`. The first push operation flushes this value onto the stack, creating an extra entry that shifts all `dup_offset` references. Historical probes used unrolled code; the daemon does not currently upload that code.
 
 ## Future Work
 

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -4,7 +4,7 @@ Each module in blocksd has a clear responsibility and minimal coupling to its ne
 
 ## protocol/
 
-The protocol package is the foundation. It contains pure, stateless functions for encoding and decoding the ROLI Blocks wire format.
+The protocol package is the foundation. It contains pure encoding and decoding functions plus stateful packing buffers and remote heap tracking, with no I/O.
 
 ### `constants.py`
 
@@ -44,11 +44,11 @@ ACK-tracked heap manager. Maintains the daemon-side view of what the device's he
 
 ### `models.py`
 
-Pydantic models for device state: `BlockType` enum, `DeviceInfo`, `TouchEvent`, `ButtonEvent`, and `TopologyConnection`.
+Device state models: the `BlockType` enum and dataclasses including `DeviceInfo`, `TouchEvent`, `ButtonEvent`, and `DeviceConnection`.
 
 ### `connection.py`
 
-The python-rtmidi to asyncio bridge. Wraps MIDI input/output with a callback that marshals incoming SysEx messages to the event loop. Provides async send/receive methods for the rest of the codebase.
+The python-rtmidi to asyncio bridge. Wraps MIDI input/output with a callback that marshals incoming SysEx messages to the event loop. Provides synchronous sends and asynchronous receives for the rest of the codebase.
 
 ### `registry.py`
 
@@ -62,7 +62,7 @@ Known device configuration item IDs and their human-readable descriptions. Used 
 
 ### `detector.py`
 
-MIDI port scanning. Polls the system's MIDI ports looking for names that match ROLI's naming convention. Validates against USB vendor ID via sysfs as a secondary check.
+MIDI port scanning. Polls the system's MIDI ports looking for names that match ROLI's naming convention. Pairs inputs and outputs by normalized name and occurrence; it does not inspect USB IDs.
 
 ### `device_group.py`
 
@@ -73,6 +73,10 @@ The big state machine. Manages the full lifecycle of a USB-connected device grou
 The TopologyManager orchestrates DeviceGroups. It runs the 1.5-second scan loop, creates DeviceGroups for new connections, and destroys them when connections are lost. It's the entry point that `daemon.py` calls.
 
 ## api/
+
+### `commands.py`
+
+Shared JSON and binary command handling for both transports. Each server has its own subscription and brightness state; validation and dispatch use one implementation.
 
 ### `server.py`
 
@@ -88,7 +92,7 @@ EventBroadcaster. Pushes device, touch, and button events to subscribed clients.
 
 ### `websocket.py`
 
-RFC 6455 WebSocket frame codec. Handles handshake, frame encoding/decoding, ping/pong, and close frames. No external WebSocket library dependency.
+RFC 6455 WebSocket frame codec. Handles frame encoding/decoding, ping/pong, and close frames; the HTTP module handles the upgrade handshake. No external WebSocket library dependency.
 
 ### `http.py`
 
@@ -102,7 +106,7 @@ The RGB565 LED grid. Provides a 15x15 pixel buffer with color conversion (RGB888
 
 ### `patterns.py`
 
-Built-in LED pattern generators: solid fill, horizontal/vertical gradient, rainbow, and checkerboard. Each generator returns a complete bitmap frame.
+Built-in LED pattern generators: solid fill, horizontal/vertical gradient, rainbow, and checkerboard. Each generator modifies the supplied grid.
 
 ## littlefoot/
 
@@ -116,7 +120,7 @@ Bytecode assembler with label resolution and FNV1a function name hashing. Conver
 
 ### `programs.py`
 
-Pre-built LittleFoot programs. The primary one is BitmapLEDProgram: a 94-byte repaint routine that reads RGB565 pixel data from the heap and calls `fillPixel` for each pixel. Currently disabled due to firmware opcode incompatibility on v1.1.0.
+Pre-built LittleFoot programs. The primary one is BitmapLEDProgram: a 100-byte repaint routine that reads RGB565 pixel data from the heap and calls `fillPixel` for each pixel. Currently disabled due to firmware opcode incompatibility on v1.1.0.
 
 ## cli/
 
@@ -126,7 +130,7 @@ The main Typer application. Defines top-level commands (`run`, `ui`, `status`) a
 
 ### `led.py`, `config.py`
 
-LED pattern and device configuration CLI commands. These connect to the running daemon via the Unix socket API to execute operations.
+LED pattern and device configuration CLI commands. These create their own TopologyManager and access MIDI directly; they are not socket clients.
 
 ### `install.py`
 
@@ -136,11 +140,11 @@ systemd service and udev rule installation/uninstallation. Generates the service
 
 ### `daemon.py`
 
-The asyncio main loop. Creates the TopologyManager, starts the API server, handles signals (SIGINT, SIGTERM), and manages the sd_notify lifecycle.
+The asyncio main loop. Creates the TopologyManager, starts the API server, handles signals (SIGINT, SIGTERM), and manages the sd_notify lifecycle. Owns and joins the manager, shutdown waiter and watchdog tasks, and unwinds partially initialized servers when startup fails.
 
 ### `config/schema.py` and `config/loader.py`
 
-Pydantic-based configuration schema and TOML file loader. Validates and applies the daemon configuration.
+Pydantic-based configuration schema and TOML file loader. Parses settings into DaemonConfig. API and web settings are applied; timing fields are currently not forwarded to the topology runtime.
 
 ### `sdnotify.py`
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-blocksd uses a TOML configuration file for daemon settings. Everything works out of the box with sensible defaults, so configuration is entirely optional. Tweak it when you want to tune scan timing, disable the web UI, or change the socket path.
+blocksd uses a TOML configuration file for daemon settings. Everything works out of the box with sensible defaults, so configuration is entirely optional. Use it to disable the web UI or change the socket path. Discovery and keepalive timing fields are currently parsed but are not connected to the runtime.
 
 ## Config File Location
 
@@ -11,7 +11,7 @@ blocksd checks two paths on startup, in order of priority:
 | 1        | `~/.config/blocksd/config.toml` | Per-user settings    |
 | 2        | `/etc/blocksd/config.toml`      | System-wide defaults |
 
-You can also pass an explicit path with `--config`:
+Only the first existing file is loaded; user and system settings are not merged. A missing explicit path falls back to normal discovery. You can pass an explicit path with `--config`:
 
 ```bash
 blocksd run --config /path/to/config.toml
@@ -23,7 +23,7 @@ All settings live under a `[daemon]` section. Here's a fully annotated example s
 
 ```toml
 [daemon]
-# Device discovery
+# Parsed timing fields (currently not applied to the runtime)
 scan_interval = 1.5            # seconds between MIDI port scans
 ping_interval_master = 0.4     # keepalive ping to USB master (seconds)
 ping_interval_dna = 1.666      # keepalive ping to DNA-connected blocks (seconds)
@@ -46,15 +46,7 @@ web_port = 9010                # HTTP / WebSocket port
 
 ### Device Discovery
 
-**`scan_interval`** controls how often the topology manager polls for new MIDI ports. The default of 1.5 seconds balances responsiveness against CPU usage. Lower values detect hot-plugged devices faster but increase polling overhead.
-
-**`ping_interval_master`** and **`ping_interval_dna`** set the keepalive intervals. The master block (USB-connected) gets pinged every 400ms; DNA-connected blocks get pinged every 1.666 seconds. These defaults match the intervals used by ROLI's own drivers.
-
-**`api_ping_timeout`** is the daemon's own timeout for declaring a device dead. The device firmware times out at 5 seconds, but blocksd waits 6 seconds before tearing down state, giving a small buffer for delayed ACKs.
-
-::: tip
-You rarely need to change the ping settings. The defaults were reverse-engineered from ROLI's C++ implementation and match the timing that keeps devices happiest.
-:::
+The schema accepts `scan_interval`, `ping_interval_master`, `ping_interval_dna`, and `api_ping_timeout`, but the daemon does not pass these values into the topology runtime. Changing them currently has no effect. Runtime constants use 1.5-second scans, 400ms master pings, 1666ms DNA pings, and a 6-second host ACK timeout. The firmware's separate API mode timeout is 5 seconds.
 
 ### Logging
 
@@ -68,7 +60,7 @@ You rarely need to change the ping settings. The defaults were reverse-engineere
 
 ### Web Dashboard
 
-**`web_enabled`** starts the HTTP and WebSocket servers alongside the daemon. Defaults to `true`, so `blocksd run` always serves the web UI. Use `--no-browser` on `blocksd ui` if you just want the server without opening a browser window.
+**`web_enabled`** starts the HTTP and WebSocket servers alongside the daemon. Defaults to `true`, so `blocksd run` serves the web UI unless disabled. Use `--no-browser` on `blocksd ui` if you just want the server without opening a browser window.
 
 **`web_host`** and **`web_port`** control the server binding. The default `127.0.0.1:9010` only accepts local connections.
 
@@ -78,7 +70,7 @@ Setting `web_host` to `0.0.0.0` exposes your device controls to the entire netwo
 
 ## Command-Line Overrides
 
-CLI flags take precedence over the config file:
+The `-v` flag enables verbose logging in addition to the config value. The `ui` command always enables the web server and replaces the configured host and port with its CLI values (including defaults):
 
 ```bash
 blocksd run -v                   # enable debug logging

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,7 +4,7 @@ ROLI Blocks are remarkable hardware: pressure-sensitive touch surfaces, 15x15 RG
 
 The catch: ROLI only ships drivers for Windows and macOS. Plug a Block into a Linux machine and you get a sad searching animation for about 5 seconds before the device powers off. No API mode activation, no touch events, no LED control, nothing.
 
-**blocksd** fixes this. It implements the complete ROLI Blocks protocol as a Linux daemon, reverse-engineered from JUCE SDK source code and extracted ROLI Connect installers.
+**blocksd** fixes this. It implements the ROLI Blocks host protocol as a Linux daemon, reverse-engineered from JUCE SDK source code and extracted ROLI Connect installers.
 
 ## What blocksd Does
 
@@ -59,7 +59,7 @@ See the [Vision document](https://github.com/hyperb1iss/blocksd/blob/main/VISION
 
 ## Project Status
 
-blocksd is in alpha, but the core feature set is complete and battle-tested on real hardware. The main gap is LittleFoot program upload, blocked by a firmware opcode incompatibility on v1.1.0 devices (the daemon works around this with unrolled fillPixel calls).
+blocksd is in alpha. Discovery and keepalive have prior hardware reports, but coverage varies by device and firmware. LittleFoot program upload is disabled because of firmware opcode incompatibilities. The unrolled fill program is also unreachable in the current daemon; accepted LED frames do not guarantee visible rendering. The hardware-independent test suite verifies software behavior, not device compatibility.
 
 | Phase                             | Status                |
 | --------------------------------- | --------------------- |

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,108 +1,112 @@
 # Installation
 
-blocksd requires Python 3.13+ and a Linux system with ALSA MIDI support. Most desktop Linux setups already have everything needed.
+blocksd runs on Linux with ALSA MIDI, Python 3.13 or newer, and a systemd user session for service management. The quick installer provides uv and a managed Python when needed.
 
-## Quick Install
+## Quick Install and Upgrade
 
-The installer script handles everything: installs blocksd, sets up udev rules, and configures a systemd user service.
+Download the release installer, inspect it, and run it as your normal user:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/hyperb1iss/blocksd/main/install.sh | bash
+curl -fsSL https://github.com/hyperb1iss/blocksd/releases/latest/download/install.sh -o install-blocksd.sh
+less install-blocksd.sh
+bash install-blocksd.sh
 ```
+
+The installer installs or upgrades the latest PyPI release in an isolated uv tool environment, installs udev rules (using sudo), and enables and restarts the systemd user service. Re-running the same command upgrades an existing installation.
+
+To select a release or skip parts of setup:
+
+```bash
+bash install-blocksd.sh --version 0.5.0
+bash install-blocksd.sh --no-udev
+bash install-blocksd.sh --no-service
+bash install-blocksd.sh --no-enable
+```
+
+The `--no-enable` option writes and reloads the service file without enabling, starting, or restarting the service. Existing systemd drop-ins are preserved. Run `bash install-blocksd.sh --help` for the complete options.
 
 ## From PyPI
 
-```bash
-uv tool install blocksd
-blocksd install    # sets up systemd service + udev rules
-```
-
-Or with pip:
+With uv already installed:
 
 ```bash
-pip install blocksd
+uv tool install --python 3.13 blocksd
 blocksd install
 ```
 
-## Arch Linux (AUR)
+Upgrade the package and restart the service to load the new code:
 
-::: code-group
-
-```bash [Stable]
-yay -S blocksd
+```bash
+uv tool upgrade blocksd
+blocksd install
+systemctl --user status blocksd
 ```
 
-```bash [Git (latest)]
-yay -S blocksd-git
-```
+A package upgrade alone does not replace the running process. If `blocksd` is not on your PATH, run `uv tool update-shell` and open a new terminal.
 
-:::
+## Arch Linux Packaging
+
+The repository contains stable and git PKGBUILDs under `packaging/aur/`. AUR publication is separate from GitHub and PyPI releases; check the package's availability and version before using an AUR helper. Package-managed installations should be upgraded through their package manager.
 
 ## From Source
+
+Install the development tools listed in [CONTRIBUTING.md](https://github.com/hyperb1iss/blocksd/blob/main/CONTRIBUTING.md), then build the dashboard before installing the service:
 
 ```bash
 git clone https://github.com/hyperb1iss/blocksd.git
 cd blocksd
-uv sync
-uv run blocksd install
+just install
+just web-build
+uv run --locked blocksd install
 ```
 
-## What `blocksd install` Sets Up
+Keep the checkout and its virtual environment at that path while the service uses it. After updating the checkout, sync dependencies, rebuild the dashboard, and rerun `uv run --locked blocksd install` to restart the service.
 
-The `install` command configures three things:
+## What Service Setup Does
 
-**udev rules** grant your user access to ROLI USB devices without requiring root. The rule file is installed to `/etc/udev/rules.d/99-roli-blocks.rules` and requires sudo for the initial setup.
+The udev file at `/etc/udev/rules.d/99-roli-blocks.rules` grants all local users read/write access to matching ROLI devices (`MODE="0666"`) and adds the `uaccess` tag. Installation requires sudo. Reconnect your devices after installing the rules.
 
-**systemd user service** auto-starts blocksd on login with watchdog monitoring. The service file goes to `~/.config/systemd/user/blocksd.service`.
-
-**Security hardening** sandboxes the daemon with `ProtectSystem=strict`, `NoNewPrivileges`, `PrivateTmp`, and other systemd security directives.
+The user service at `~/.config/systemd/user/blocksd.service` starts on login and uses systemd readiness and watchdog notifications. Its sandbox includes `ProtectSystem=strict`, `NoNewPrivileges`, and `PrivateTmp`.
 
 ```bash
-blocksd install                  # full setup (udev + systemd)
+blocksd install                  # udev + service + enable and restart
 blocksd install --no-udev        # skip udev rules
-blocksd install --no-enable      # install but don't auto-start
+blocksd install --no-enable      # write/reload service without restarting
+blocksd install --no-service     # skip the service
 ```
 
-## Verifying the Installation
-
-Plug in a ROLI Block device and check that blocksd can see it:
+## Verify
 
 ```bash
+systemctl --user status blocksd
+journalctl --user -u blocksd --no-pager -n 30
 blocksd status
 ```
 
-You should see your device's MIDI port listed. For full details including serial number, device type, and battery level:
+Open `http://localhost:9010` for the running daemon's dashboard. Do not launch `blocksd ui` alongside the service: that command starts another daemon.
+
+The `status --probe`, `led`, and `config` commands open separate MIDI sessions. Stop the service before using those commands, then restart it afterward.
+
+## Native Dependencies
+
+ALSA runtime support is required. If python-rtmidi needs to compile from source, install a C/C++ toolchain, pkg-config, and ALSA/JACK development headers. For Debian or Ubuntu:
 
 ```bash
-blocksd status --probe
+sudo apt-get install build-essential pkg-config libasound2-dev libjack-jackd2-dev
 ```
 
-## Uninstalling
+Use the equivalent development packages for your distribution. The installer does not install distribution packages.
+
+## Uninstall
 
 ```bash
-blocksd uninstall    # removes systemd service and udev rules
+blocksd uninstall               # service and udev rules
+uv tool uninstall blocksd       # Python package (uv installations)
 ```
 
-## Dependencies
-
-blocksd's only system dependency is ALSA development headers, which are needed by python-rtmidi. These are typically already installed on desktop Linux systems.
-
-::: code-group
-
-```bash [Debian / Ubuntu]
-sudo apt install libasound2-dev
-```
-
-```bash [Fedora]
-sudo dnf install alsa-lib-devel
-```
-
-```bash [Arch]
-sudo pacman -S alsa-lib
-```
-
-:::
+User configuration is retained. For a distribution package, remove the package through its package manager.
 
 ## Next Steps
 
-- [Quick Start](./quick-start): connect your first device and try LED patterns
+- [Quick Start](./quick-start): device discovery and standalone CLI tools
+- [LittleFoot status](../architecture/littlefoot): why accepted LED writes do not guarantee visible output

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -11,6 +11,7 @@ Plug in a ROLI Block via USB. If you've run `blocksd install`, the udev rules ar
 Start blocksd in the foreground with verbose logging to see what's happening:
 
 ```bash
+systemctl --user stop blocksd   # if the service is installed
 blocksd run -v
 ```
 
@@ -47,19 +48,25 @@ blocksd status
 For full details including serial number, firmware version, and battery level:
 
 ```bash
+systemctl --user stop blocksd   # also stop any foreground daemon
 blocksd status --probe
+systemctl --user start blocksd
 ```
 
 ## Try LED Patterns
+
+The LED and config commands open their own MIDI sessions. Stop the service and any foreground daemon before using them. LED commands remain running until Ctrl+C; config commands probe for about eight seconds. Restart the service afterward.
+
+The current daemon does not upload its LittleFoot LED renderer (firmware opcode compatibility remains unresolved). LED commands and API frames can update heap data, but an accepted write does not establish visible LED output. See the [LittleFoot notes](../architecture/littlefoot).
 
 If you have a Lightpad Block or Lightpad Block M, try the built-in LED patterns:
 
 ```bash
 blocksd led solid '#ff00ff'                      # solid magenta
-blocksd led rainbow                               # animated rainbow
+blocksd led rainbow                               # static rainbow
 blocksd led gradient ff0000 0000ff                # red → blue gradient
 blocksd led gradient ff0000 0000ff --vertical     # vertical gradient
-blocksd led checkerboard ff0000 00ff00            # 2x2 checkerboard
+blocksd led checkerboard ff0000 00ff00            # 1x1 checkerboard
 blocksd led checkerboard ff0000 00ff00 --size 3   # 3x3 checkerboard
 blocksd led off                                   # lights off
 ```
@@ -75,6 +82,8 @@ blocksd config set 10 50         # set velocity sensitivity to 50
 ```
 
 ## Launch the Web Dashboard
+
+If blocksd is already running, open `http://localhost:9010` directly. Use `blocksd ui` only when no daemon is running; the command starts its own daemon.
 
 For a visual overview of your connected devices:
 

--- a/docs/guide/web-dashboard.md
+++ b/docs/guide/web-dashboard.md
@@ -11,7 +11,7 @@ blocksd ui --port 8080           # custom port
 
 This starts the daemon with the web server and opens your browser to the dashboard. The web UI communicates with blocksd over WebSocket for live updates.
 
-You can also enable the web server permanently by setting `web.enabled = true` in your config file, so it starts automatically with `blocksd run`.
+The web server is enabled by default (`web_enabled = true` under `[daemon]` in the config file). If the systemd service or a foreground daemon is already running, open `http://localhost:9010` directly. The `ui` command starts another daemon; it does not attach to the existing service.
 
 ## Dashboard Features
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@ layout: home
 hero:
   name: blocksd
   text: ROLI Blocks on Linux
-  tagline: "Full ROLI protocol stack, reverse-engineered from scratch. Topology discovery, keepalive, LED bitmap streaming, pressure-sensitive touch, device configuration. Your Blocks, finally alive on Linux."
+  tagline: "ROLI Blocks host protocol, implemented from reference code. Topology discovery, keepalive, LED bitmap streaming, pressure-sensitive touch, device configuration. Your Blocks, finally alive on Linux."
   actions:
     - theme: brand
       text: Get Started

--- a/docs/protocol/index.md
+++ b/docs/protocol/index.md
@@ -69,7 +69,7 @@ Messages flow in both directions. Host-to-device messages include commands (begi
 
 ## USB Device Identification
 
-ROLI devices use vendor ID `0x2AF4`. blocksd identifies devices by scanning MIDI port names for "BLOCK" or "Block", then validates against the USB vendor ID via sysfs.
+ROLI devices use vendor ID `0x2AF4`. blocksd identifies devices by scanning MIDI port names for "BLOCK" or "Block". USB IDs are reference information; the detector does not consult sysfs.
 
 | USB PID  | Device              |
 | -------- | ------------------- |

--- a/docs/protocol/lifecycle.md
+++ b/docs/protocol/lifecycle.md
@@ -23,7 +23,7 @@ stateDiagram-v2
 
 ### 1. Scan MIDI Ports
 
-The topology manager polls MIDI ports every 1.5 seconds (configurable via `scan_interval`). It looks for port names containing "BLOCK" or "Block", then validates the USB vendor ID (`0x2AF4`) via sysfs as a secondary check.
+The topology manager polls MIDI ports every 1.5 seconds (currently a runtime constant). It looks for port names containing "BLOCK" or "Block". Inputs and outputs are paired by normalized name and occurrence.
 
 ### 2. Open MIDI Connection
 
@@ -31,7 +31,7 @@ When a matching port is found, blocksd opens the MIDI input and output pair. The
 
 ### 3. Request Serial Number
 
-blocksd sends the serial dump request: `F0 00 21 10 78 3F F7`. This is retried every 300ms until a response arrives. The response contains a MAC address prefix (`48:B6:20:`) followed by the 16-character serial number.
+blocksd sends the serial dump request: `F0 00 21 10 78 3F F7`. This is retried every 300ms for up to 5 seconds. The response contains a MAC address prefix (`48:B6:20:`) followed by the 16-character serial number.
 
 ### 4. Parse Serial and Identify Device
 
@@ -65,7 +65,7 @@ Each ping is a `deviceCommandMessage` with command `0x03`. The device responds w
 
 ### 9. Monitor ACKs
 
-blocksd tracks the last ACK time for each device. If a device hasn't responded within 5000ms, it's considered disconnected. The daemon removes the device from its internal state and emits a `device_removed` event.
+blocksd tracks the last ACK time for each device. If a device hasn't responded within 6000ms, it's considered disconnected. The daemon removes the device from its internal state and emits a `device_removed` event.
 
 ### 10. Handle Topology Changes
 
@@ -109,9 +109,9 @@ sequenceDiagram
 
 The lifecycle is designed to be self-healing:
 
-- **Serial timeout**: retried every 300ms until the device responds
-- **Topology timeout**: re-requested after a configurable delay
-- **Missed ACK**: device is marked as timed out after 5000ms, then rediscovered
+- **Serial timeout**: retried every 300ms for up to 5 seconds, then topology discovery proceeds without the master serial
+- **Topology timeout**: re-requested using the runtime retry constants
+- **Missed ACK**: device is marked as timed out after 6000ms, then rediscovered
 - **MIDI port disappears**: the DeviceGroup is destroyed and all device state is cleaned up
 - **Unexpected disconnect**: the daemon continues scanning and will reconnect automatically when the device reappears
 

--- a/docs/protocol/messages.md
+++ b/docs/protocol/messages.md
@@ -41,7 +41,7 @@ Acknowledges receipt of a host-to-device packet. Contains a 10-bit packet counte
 
 Touch events report finger position and pressure on the device surface. The `x` and `y` fields are 12-bit fixed-point values representing position on the touch surface. The `z` field is an 8-bit pressure value. Velocity variants add 8-bit velocity components for each axis.
 
-blocksd normalizes these to floating-point values in the 0.0-1.0 range before exposing them through the external API.
+blocksd normalizes position and pressure to 0.0-1.0 before exposing them through the API. Velocity components are signed (approximately -1.0 to 1.0); raw zero denotes no velocity.
 
 ### configMessage (0x18)
 
@@ -114,8 +114,8 @@ Each command starts with a 3-bit command ID:
 
 | ID  | Name                     | Extra Bits                   | Description                             |
 | --- | ------------------------ | ---------------------------- | --------------------------------------- |
-| `0` | endOfPacket              | —                            | End of this packet's changes            |
-| `1` | endOfChanges             | —                            | All changes complete                    |
+| `0` | endOfPacket              | :                            | End of this packet's changes            |
+| `1` | endOfChanges             | :                            | All changes complete                    |
 | `2` | skipBytesFew             | 4b count                     | Skip 1-15 heap bytes                    |
 | `3` | skipBytesMany            | 8b count                     | Skip 1-255 heap bytes                   |
 | `4` | setSequenceOfBytes       | (8b value + 1b continue) x N | Write a sequence of distinct bytes      |

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,6 +1,6 @@
 # External API
 
-blocksd exposes two APIs for building your own integrations: a Unix domain socket for local IPC (fast, zero overhead) and a WebSocket for browser and network clients. Both speak the same protocol, so code written for one works with the other.
+blocksd exposes two APIs for building your own integrations: a Unix domain socket for local IPC and a WebSocket for browser and network clients. Both share command validation and JSON payloads, but use different transport framing.
 
 ## Connection Methods
 
@@ -21,7 +21,7 @@ Browser and network clients. Used by the web dashboard (`blocksd ui`).
 
 ## Protocol Overview
 
-A single connection can mix two message types:
+On the Unix socket, a single connection can mix two message types:
 
 - **NDJSON**: newline-delimited JSON for control messages and events
 - **Binary LED frames**: fixed-size 685-byte packets for LED streaming
@@ -30,6 +30,8 @@ The server distinguishes inbound message types by the first byte:
 
 - `0xBD`: binary LED frame
 - Anything else: read as newline-delimited JSON
+
+WebSocket clients send JSON in text messages and the same 685-byte LED packet in binary messages. Binary acknowledgements arrive as one-byte binary messages; JSON responses and events arrive as text messages. The custom WebSocket codec has not been validated against a full conformance suite.
 
 ## Recommended Client Strategy
 
@@ -63,7 +65,7 @@ Pixel order is row-major: pixel `i` maps to `x = i % 15`, `y = i // 15`. Each pi
 
 ### Binary Ack
 
-Each frame write returns exactly one byte:
+Each parsed binary frame write returns one acknowledgement byte (inside a binary WebSocket message on that transport):
 
 | Value  | Meaning  |
 | ------ | -------- |
@@ -72,9 +74,12 @@ Each frame write returns exactly one byte:
 
 `0x00` means the device was unavailable, the `uid` was unknown, or the payload was invalid. Early rejections during device startup are retryable.
 
+Acceptance confirms a daemon-side heap update, not a hardware acknowledgement or visible display change. LittleFoot renderer upload is currently disabled; see the [firmware limitation](../architecture/littlefoot).
+
 ### Python Example
 
 ```python
+import os
 import socket
 import struct
 
@@ -86,7 +91,7 @@ uid = 42
 frame = struct.pack("<BBQ", MAGIC, TYPE_FRAME, uid) + PIXELS
 
 with socket.socket(socket.AF_UNIX, socket.SOCK_STREAM) as sock:
-    sock.connect("/tmp/blocksd/blocksd.sock")
+    sock.connect(os.path.join(os.environ.get("XDG_RUNTIME_DIR", "/tmp"), "blocksd/blocksd.sock"))
     sock.sendall(frame)
     accepted = sock.recv(1) == b"\x01"
     print("accepted:", accepted)
@@ -107,7 +112,7 @@ Health check and basic daemon info.
 ```json
 {
   "type": "pong",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "uptime_seconds": 12,
   "device_count": 2,
   "id": "req-1"
@@ -135,7 +140,7 @@ List all connected devices with capabilities and battery status.
       "grid_height": 15,
       "battery_level": 31,
       "battery_charging": false,
-      "firmware_version": ""
+      "firmware_version": null
     }
   ],
   "id": "req-2"
@@ -176,7 +181,7 @@ Set the LED brightness for a device.
 { "type": "brightness_ack", "uid": 42, "ok": true }
 ```
 
-Value is clamped to 0-255. Brightness is sticky daemon-side state, applied to future frame writes before RGB565 conversion.
+Value is clamped to 0-255. Brightness is sticky per-server state, applied to future frame writes before RGB565 conversion. Unix socket and WebSocket servers hold separate brightness settings; changing one does not change the other.
 
 ### `subscribe`
 
@@ -190,9 +195,39 @@ Subscribe to real-time event streams.
 { "type": "subscribed", "events": ["button", "device", "touch"] }
 ```
 
+### `config_get` and `config_set`
+
+Read cached configuration values for a device or request a setting change:
+
+```json
+{ "type": "config_get", "uid": 42 }
+```
+
+```json
+{
+  "type": "config_values",
+  "uid": 42,
+  "values": [{ "item": 10, "value": 50, "min": 0, "max": 100 }]
+}
+```
+
+```json
+{ "type": "config_set", "uid": 42, "item": 10, "value": 50 }
+```
+
+```json
+{ "type": "config_ack", "uid": 42, "item": 10, "ok": true }
+```
+
+The values and ranges above are illustrative; use the device's reported ranges. A successful set response confirms dispatch, not persistence. Subscribe to `config` for subsequent `config_changed` events.
+
+### `topology`
+
+Send `{ "type": "topology" }` to receive `topology_response` with `devices` and `connections` arrays. Each connection contains `device1_uid`, `device2_uid`, `port1`, and `port2`. Subscribe to `topology` for `topology_changed` events with the same arrays.
+
 ## Event Stream
 
-Subscribed events are emitted as NDJSON on the same socket.
+Subscribed events are emitted as NDJSON on the Unix socket or JSON text messages on WebSocket. Supported categories are `device`, `touch`, `button`, `config`, and `topology`. A new subscription replaces the previous one on that connection.
 
 ### Device Events
 
@@ -207,7 +242,7 @@ Subscribed events are emitted as NDJSON on the same socket.
     "grid_height": 15,
     "battery_level": 85,
     "battery_charging": false,
-    "firmware_version": ""
+    "firmware_version": null
   }
 }
 ```
@@ -223,7 +258,7 @@ Subscribed events are emitted as NDJSON on the same socket.
   "type": "touch",
   "uid": 42,
   "action": "start",
-  "touch_index": 0,
+  "index": 0,
   "x": 0.5,
   "y": 0.75,
   "z": 0.8,
@@ -238,10 +273,16 @@ Action is one of: `start`, `move`, `end`.
 ### Button Events
 
 ```json
-{ "type": "button", "uid": 42, "button_id": 0, "action": "press" }
+{ "type": "button", "uid": 42, "action": "press" }
 ```
 
-Action is one of: `press`, `release`.
+Action is one of: `press`, `release`. The current API does not expose the protocol button ID.
+
+### Configuration Events
+
+```json
+{ "type": "config_changed", "uid": 42, "item": 10, "value": 50 }
+```
 
 ### Backpressure
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -16,11 +16,11 @@ The daemon scans for ROLI devices, activates API mode, and maintains keepalive p
 
 When running under systemd, the daemon sends `READY=1` via sd_notify and periodic watchdog heartbeats.
 
-| Flag                      | Short     | Description                      |
-| ------------------------- | --------- | -------------------------------- |
-| `--verbose`               | `-v`      | Enable debug logging             |
-| `--foreground / --daemon` | `-f / -d` | Run mode (foreground is default) |
-| `--config`                |           | Path to TOML config file         |
+| Flag                      | Short     | Description                                        |
+| ------------------------- | --------- | -------------------------------------------------- |
+| `--verbose`               | `-v`      | Enable debug logging                               |
+| `--foreground / --daemon` | `-f / -d` | Accepted for compatibility; both run in foreground |
+| `--config`                |           | Path to TOML config file                           |
 
 ## `blocksd ui`
 
@@ -59,7 +59,7 @@ The quick scan lists MIDI ports matching ROLI's naming convention. The `--probe`
 
 ## `blocksd led`
 
-Control the 15x15 LED grid on Lightpad Block and Lightpad Block M. These commands connect to the running daemon via the Unix socket API, so the daemon must be running first.
+Control the 15x15 LED grid on Lightpad Block and Lightpad Block M. These commands start their own MIDI discovery and keepalive session, apply the pattern as devices connect, and remain running until Ctrl+C. Stop any existing daemon first. Program upload is disabled, so heap writes do not guarantee visible LED output (see [LittleFoot](../architecture/littlefoot)).
 
 ### `blocksd led solid`
 
@@ -72,11 +72,11 @@ blocksd led solid ff00ff             # hash is optional
 
 ### `blocksd led rainbow`
 
-Sweep a rainbow gradient across the grid.
+Generate a static rainbow gradient across the grid.
 
 ```bash
 blocksd led rainbow
-blocksd led rainbow --brightness 128 # dimmer rainbow (0-255)
+blocksd led rainbow --brightness 0.5 # dimmer rainbow (0.0-1.0)
 ```
 
 ### `blocksd led gradient`
@@ -93,7 +93,7 @@ blocksd led gradient ff0000 0000ff --vertical    # vertical (top → bottom)
 Draw a checkerboard pattern.
 
 ```bash
-blocksd led checkerboard ff0000 00ff00             # 2x2 squares (default)
+blocksd led checkerboard ff0000 00ff00             # 1x1 squares (default)
 blocksd led checkerboard ff0000 00ff00 --size 3    # 3x3 squares
 blocksd led checkerboard ff0000 00ff00 --size 5    # 5x5 squares
 ```
@@ -108,7 +108,7 @@ blocksd led off
 
 ## `blocksd config`
 
-Read and write device configuration values. Connects to the running daemon.
+Read and write device configuration values through a separate MIDI session lasting about eight seconds. Stop any running daemon first and restart it afterward. The `get` command reports the value cached when discovery fires; an early `not reported` result does not establish that the device lacks that setting. For an existing daemon, use the API `config_get` and `config_set` requests.
 
 ### `blocksd config list`
 
@@ -141,7 +141,7 @@ Set up systemd service and udev rules. The udev rule installation requires sudo.
 ```bash
 blocksd install                  # full setup (udev + systemd + auto-start)
 blocksd install --no-udev        # skip udev rules
-blocksd install --no-enable      # install service but don't enable on boot
+blocksd install --no-enable      # write/reload service without enabling or restarting
 blocksd install --no-service     # skip systemd service entirely
 ```
 
@@ -154,7 +154,7 @@ This creates:
 
 ## `blocksd uninstall`
 
-Remove the systemd service and udev rules.
+Remove the systemd service and udev rules. The Python package and user configuration remain; remove a uv tool installation separately with `uv tool uninstall blocksd`.
 
 ```bash
 blocksd uninstall

--- a/docs/reference/devices.md
+++ b/docs/reference/devices.md
@@ -1,6 +1,6 @@
 # Supported Devices
 
-ROLI shipped a surprisingly diverse family of Blocks devices: pressure-sensitive pads, keyboard strips, control surfaces, loop controllers, and more. blocksd supports all known Blocks devices through the topology and keepalive protocol. LED bitmap streaming is currently limited to the Lightpad family, which is the only device type with an addressable RGB grid.
+ROLI shipped a surprisingly diverse family of Blocks devices: pressure-sensitive pads, keyboard strips, control surfaces, loop controllers, and more. blocksd identifies known Blocks serial prefixes and manages discovered devices through the topology and keepalive protocol. Compatibility must be checked per device and firmware. LED bitmap streaming is currently limited to the Lightpad family, which is the only device type with an addressable RGB grid.
 
 ## Device Matrix
 
@@ -8,24 +8,26 @@ ROLI shipped a surprisingly diverse family of Blocks devices: pressure-sensitive
 | ----------------------- | -------- | ------------- | -------- | ----------- |
 | Lightpad Block          | `0x0900` | `LPB`         | 15x15    | ✅ Tested   |
 | Lightpad Block M        | `0x0900` | `LPM`         | 15x15    | ✅ Tested   |
-| LUMI Keys Block         | `0x0E00` | `LKB`         | —        | ✅ Tested   |
-| Seaboard Block          | `0x0700` | `SBB`         | —        | 🔲 Untested |
-| Live Block              | —        | `LIC`         | —        | 🔲 Untested |
-| Loop Block              | —        | `LOC`         | —        | 🔲 Untested |
-| Developer Control Block | —        | `DCB`         | —        | 🔲 Untested |
-| Touch Block             | —        | `TCB`         | —        | 🔲 Untested |
-| Seaboard RISE 25        | `0x0200` | —             | —        | 🔲 Untested |
-| Seaboard RISE 49        | `0x0210` | —             | —        | 🔲 Untested |
-| ROLI Piano (49-key)     | `0x0F00` | —             | —        | 🔲 Untested |
-| ROLI Airwave Pedal      | `0x1000` | —             | —        | 🔲 Untested |
+| LUMI Keys Block         | `0x0E00` | `LKB`         | :        | ✅ Tested   |
+| Seaboard Block          | `0x0700` | `SBB`         | :        | 🔲 Untested |
+| Live Block              | :        | `LIC`         | :        | 🔲 Untested |
+| Loop Block              | :        | `LOC`         | :        | 🔲 Untested |
+| Developer Control Block | :        | `DCB`         | :        | 🔲 Untested |
+| Touch Block             | :        | `TCB`         | :        | 🔲 Untested |
+| Seaboard RISE 25        | `0x0200` | :             | :        | 🔲 Untested |
+| Seaboard RISE 49        | `0x0210` | :             | :        | 🔲 Untested |
+| ROLI Piano (49-key)     | `0x0F00` | :             | :        | 🔲 Untested |
+| ROLI Airwave Pedal      | `0x1000` | :             | :        | 🔲 Untested |
 
 ## What "Tested" Means
 
-**Tested** devices have been physically connected and verified through the full lifecycle: serial request, topology discovery, API mode activation, keepalive, and (where applicable) LED control and touch events.
+**Tested** records prior project hardware reports, not a release-by-release certification. A passing software test suite does not establish physical device compatibility or visible LED rendering.
 
-**Untested** devices are supported at the protocol level. blocksd will discover them, read their serial numbers, include them in topology, and maintain API mode keepalive. But the specific device behavior hasn't been validated with real hardware.
+**Untested** means no hardware validation is recorded here. A USB PID or serial prefix in the source does not guarantee discovery or support. Non-Blocks products in the table are identification references only; the MIDI scanner requires a matching Blocks port name.
 
 ## LED Capabilities
+
+The daemon currently skips LittleFoot program upload. An accepted frame is a heap write, not proof of visible rendering (see [LittleFoot status](../architecture/littlefoot)).
 
 Only Lightpad Block and Lightpad Block M expose a 15x15 RGB LED grid through the bitmap frame protocol. These are the only devices that:
 
@@ -33,31 +35,15 @@ Only Lightpad Block and Lightpad Block M expose a 15x15 RGB LED grid through the
 - Accept binary LED frame writes
 - Respond to `blocksd led` CLI commands
 
-Other devices (LUMI Keys, Seaboard, Control Blocks) are discoverable and kept alive, but they advertise `grid_width = 0` / `grid_height = 0` and reject frame writes.
+Other recognized Blocks devices can participate in discovery and keepalive, but they advertise `grid_width = 0` / `grid_height = 0` and reject frame writes.
 
-## Touch Capabilities
+## Touch and Button Events
 
-Touch events are supported on devices with pressure-sensitive surfaces:
-
-- **Lightpad Block / M**: 15x15 continuous touch surface with X, Y, Z (pressure) and velocity
-- **Seaboard Block**: continuous pitch surface with MPE expression
-- **LUMI Keys**: key-level pressure sensitivity
-
-Touch events are normalized to floating-point values (0.0 to 1.0) regardless of the device's native resolution.
-
-## Button Capabilities
-
-Control-style devices emit button press/release events:
-
-- **Live Block**: transport controls
-- **Loop Block**: loop controls
-- **Developer Control Block**: programmable buttons
-
-Buttons are identified by a 12-bit button ID.
+The decoder handles Blocks touch and button messages when a device emits them. Touch coordinates and pressure are normalized; velocity is signed. The API exposes touch position, pressure, velocity, and contact index, plus button press/release actions. The protocol button ID is not currently included in the API event. Ordinary MIDI notes and MPE events are not translated into touch events by this API.
 
 ## DNA Mesh Networking
 
-All Blocks devices support DNA magnetic connectors for mesh networking. When blocks are physically connected:
+Blocks devices with DNA magnetic connectors can form a mesh. When blocks are physically connected:
 
 - The USB-connected block becomes the master (topology index 0)
 - DNA-connected blocks get indices 1+
@@ -75,14 +61,8 @@ Devices have limited memory for LittleFoot programs:
 | Pad Block (Lightpad) | 7200 bytes     | 800 bytes |
 | Control Block        | 3000 bytes     | 800 bytes |
 
-The BitmapLEDProgram (LED repaint routine) is 94 bytes, leaving the rest of the heap available for pixel data.
+The BitmapLEDProgram (LED repaint routine) is 100 bytes, leaving the rest of the heap available for pixel data.
 
 ## USB Identification
 
-All ROLI devices share vendor ID `0x2AF4`. blocksd identifies devices by:
-
-1. Scanning MIDI port names for "BLOCK" or "Block"
-2. Validating the USB vendor ID via sysfs (fallback check)
-3. Requesting the serial number to determine the exact device type
-
-The MIDI port name check is primary because it works across all Linux MIDI subsystems. The sysfs check provides additional confidence when the port name is ambiguous.
+ROLI's vendor ID is `0x2AF4`. The daemon scans MIDI port names for the words "BLOCK" or "Block", pairs matching inputs and outputs, and uses serial prefixes to identify device types. The current detector does not inspect USB IDs or sysfs.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -12,7 +12,7 @@ Common issues and how to fix them. If your problem isn't here, check the [GitHub
 lsusb | grep 2af4
 ```
 
-If the device appears in `lsusb` but not in `blocksd status`, the issue is MIDI port naming.
+If the device appears in `lsusb` but not in `blocksd status`, check ALSA driver binding, permissions, and MIDI port naming.
 
 **Check MIDI ports directly**:
 
@@ -57,13 +57,11 @@ Common causes:
 
 **Symptom**: `blocksd led solid '#ff00ff'` returns but the Lightpad doesn't change.
 
-**Is the daemon running?** LED commands connect to the running daemon via Unix socket. Start the daemon first:
+**Check the renderer limitation first.** The daemon currently skips LittleFoot program upload. Heap writes may be accepted without changing the display. See [LittleFoot status](./architecture/littlefoot).
 
-```bash
-blocksd run
-```
+The LED CLI opens its own MIDI session and stays running until Ctrl+C. Stop the service before using it; API clients should instead connect to the running daemon.
 
-**Is it a Lightpad?** Only Lightpad Block and Lightpad Block M support LED bitmap control. Other devices like LUMI Keys don't have an addressable LED grid.
+**Is it a Lightpad?** Only Lightpad Block and Lightpad Block M support LED bitmap control. The current bitmap API does not expose a grid for devices such as LUMI Keys.
 
 **Check the socket**:
 
@@ -80,7 +78,7 @@ ls -la $XDG_RUNTIME_DIR/blocksd/blocksd.sock
 The daemon should idle near 0% CPU when devices are connected and stable. High CPU usually means:
 
 - **Rapid reconnect loop**: a device is repeatedly connecting and disconnecting. Check `blocksd run -v` for rapid serial request cycles. This can happen with a damaged USB cable.
-- **Scan interval too low**: if you've set `scan_interval` below 0.5 seconds, the MIDI port polling may be consuming CPU.
+- **Concurrent hardware sessions**: the LED/config CLI and `status --probe` create their own MIDI sessions. Run them with the service stopped. The TOML timing fields currently have no runtime effect.
 
 ## Device Disconnects After 5 Seconds
 
@@ -139,9 +137,10 @@ blocksd install
 ss -tlnp | grep 9010
 ```
 
-Try a different port:
+If the service is already running, open `http://localhost:9010` directly. To use `ui`, stop the service first; changing only the HTTP port does not give the second daemon a separate Unix socket:
 
 ```bash
+systemctl --user stop blocksd
 blocksd ui --port 8080
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -1,119 +1,68 @@
 #!/usr/bin/env bash
-# blocksd installer,installs via uv/pipx and sets up systemd + udev
+# Install or upgrade blocksd and configure Linux device/service integration.
 set -euo pipefail
 
-ELECTRIC_PURPLE='\033[38;2;225;53;255m'
-NEON_CYAN='\033[38;2;128;255;234m'
-SUCCESS_GREEN='\033[38;2;80;250;123m'
-ERROR_RED='\033[38;2;255;99;99m'
-ELECTRIC_YELLOW='\033[38;2;241;250;140m'
-BOLD='\033[1m'
-RESET='\033[0m'
+bootstrap_uv() (
+    # The subshell owns both the temporary file and its EXIT cleanup.
+    bootstrap=$(mktemp)
+    trap 'rm -f "$bootstrap"' EXIT
+    curl --proto '=https' --tlsv1.2 -fsSL https://astral.sh/uv/install.sh -o "$bootstrap"
+    UV_UNMANAGED_INSTALL="$HOME/.local/bin" sh "$bootstrap"
+)
 
-info()  { printf "${NEON_CYAN}${BOLD}>>>${RESET} %s\n" "$*"; }
-ok()    { printf "${SUCCESS_GREEN}${BOLD} ✓${RESET} %s\n" "$*"; }
-warn()  { printf "${ELECTRIC_YELLOW}${BOLD} !${RESET} %s\n" "$*"; }
-fail()  { printf "${ERROR_RED}${BOLD} ✗${RESET} %s\n" "$*" >&2; exit 1; }
+main() {
+    local requirement='blocksd' uv_bin tool_bin
+    local -a setup_args=()
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --version)
+                [[ $# -ge 2 && "$2" =~ ^[0-9]+(\.[0-9]+)*([abrc]|post|dev|[0-9.])*([+][a-zA-Z0-9.]+)?$ ]] || {
+                    printf 'Expected a package version after --version\n' >&2; return 2;
+                }
+                requirement="blocksd==$2"
+                shift 2
+                ;;
+            --no-udev|--no-service|--no-enable) setup_args+=("$1"); shift ;;
+            -h|--help)
+                cat <<'HELP'
+Usage: bash install.sh [--version VERSION] [--no-udev] [--no-service] [--no-enable]
 
-printf "\n${ELECTRIC_PURPLE}${BOLD}"
-printf "  ┌──────────────────────────────────┐\n"
-printf "  │         🔌 blocksd               │\n"
-printf "  │   ROLI Blocks Linux Daemon       │\n"
-printf "  └──────────────────────────────────┘\n"
-printf "${RESET}\n"
+Install or upgrade blocksd using uv and managed Python 3.13.
+By default install udev rules (sudo), enable the user service, and restart it.
+  --version VERSION  Install a specific PyPI version (default: latest)
+  --no-udev          Skip device permission rules (no sudo needed)
+  --no-service       Skip all systemd setup
+  --no-enable        Write/reload service without enabling or restarting it
+Run as your normal user. Requires Linux, curl, and a systemd user session
+unless --no-service is used. Re-running upgrades the package and restarts it.
+HELP
+                return 0
+                ;;
+            *) printf 'Unknown option: %s\n' "$1" >&2; return 2 ;;
+        esac
+    done
 
-# ─── Install blocksd ──────────────────────────────────────────────
-info "Installing blocksd..."
+    [[ "$(uname -s)" == Linux ]] || { printf 'blocksd requires Linux\n' >&2; return 1; }
+    [[ "$(id -u)" != 0 ]] || { printf 'Run as your normal user, without sudo\n' >&2; return 1; }
+    uv_bin=$(command -v uv || true)
+    if [[ -z "$uv_bin" ]]; then
+        command -v curl >/dev/null || { printf 'Install curl first\n' >&2; return 1; }
+        printf 'Installing uv...\n'
+        bootstrap_uv
+        uv_bin="$HOME/.local/bin/uv"
+    fi
 
-if command -v uv &>/dev/null; then
-    uv tool install blocksd
-    ok "Installed via uv"
-elif command -v pipx &>/dev/null; then
-    pipx install blocksd
-    ok "Installed via pipx"
-elif command -v pip &>/dev/null; then
-    pip install --user blocksd
-    ok "Installed via pip"
-else
-    fail "No Python package manager found. Install uv: https://docs.astral.sh/uv/"
-fi
+    printf 'Installing %s...\n' "$requirement"
+    "$uv_bin" tool install --python 3.13 --managed-python --upgrade "$requirement"
+    tool_bin=$("$uv_bin" tool dir --bin)
+    [[ -x "$tool_bin/blocksd" ]] || { printf 'uv did not install an executable blocksd\n' >&2; return 1; }
+    "$tool_bin/blocksd" install "${setup_args[@]}"
+    printf 'Installed: %s/blocksd\n' "$tool_bin"
+    case ":$PATH:" in
+        *":$tool_bin:"*) ;;
+        *) printf 'Add %s to PATH to run blocksd from your shell.\n' "$tool_bin" ;;
+    esac
+}
 
-# ─── Verify ───────────────────────────────────────────────────────
-if ! command -v blocksd &>/dev/null; then
-    warn "blocksd not found on PATH,you may need to add ~/.local/bin to your PATH"
-    warn "  export PATH=\"\$HOME/.local/bin:\$PATH\""
-fi
-
-# ─── udev rules ──────────────────────────────────────────────────
-info "Installing udev rules for ROLI devices..."
-
-UDEV_RULE='# ROLI Blocks devices (VID 0x2AF4)
-SUBSYSTEM=="usb", ATTR{idVendor}=="2af4", MODE="0666", TAG+="uaccess"
-SUBSYSTEM=="sound", ATTR{idVendor}=="2af4", MODE="0666", TAG+="uaccess"'
-
-UDEV_PATH="/etc/udev/rules.d/99-roli-blocks.rules"
-
-if [[ -f "$UDEV_PATH" ]]; then
-    warn "udev rules already exist at $UDEV_PATH,skipping"
-else
-    echo "$UDEV_RULE" | sudo tee "$UDEV_PATH" >/dev/null
-    sudo udevadm control --reload-rules
-    sudo udevadm trigger
-    ok "udev rules installed"
-fi
-
-# ─── systemd user service ────────────────────────────────────────
-info "Installing systemd user service..."
-
-SERVICE_DIR="$HOME/.config/systemd/user"
-SERVICE_PATH="$SERVICE_DIR/blocksd.service"
-mkdir -p "$SERVICE_DIR"
-
-BLOCKSD_BIN=$(command -v blocksd 2>/dev/null || echo "$HOME/.local/bin/blocksd")
-
-cat > "$SERVICE_PATH" <<EOF
-[Unit]
-Description=blocksd: ROLI Blocks Linux Daemon
-Documentation=https://github.com/hyperb1iss/blocksd
-After=sound.target
-
-[Service]
-Type=notify
-ExecStart=$BLOCKSD_BIN run --daemon
-Restart=on-failure
-RestartSec=5
-WatchdogSec=30
-
-# Security hardening
-ProtectSystem=strict
-PrivateTmp=true
-NoNewPrivileges=true
-ProtectKernelTunables=true
-ProtectKernelModules=true
-ProtectControlGroups=true
-
-[Install]
-WantedBy=default.target
-EOF
-
-systemctl --user daemon-reload
-ok "systemd service installed"
-
-# ─── Enable? ─────────────────────────────────────────────────────
-printf "\n"
-read -rp "$(printf "${NEON_CYAN}${BOLD}>>>${RESET} Enable and start blocksd now? [Y/n] ")" ENABLE
-ENABLE="${ENABLE:-Y}"
-
-if [[ "$ENABLE" =~ ^[Yy]$ ]]; then
-    systemctl --user enable --now blocksd
-    ok "blocksd is running"
-    printf "\n"
-    info "Check status:  systemctl --user status blocksd"
-    info "View logs:     journalctl --user -u blocksd -f"
-else
-    ok "Service installed but not started"
-    printf "\n"
-    info "Start later:   systemctl --user enable --now blocksd"
-fi
-
-printf "\n${SUCCESS_GREEN}${BOLD} ✓ Installation complete${RESET}\n\n"
+# Parse the whole script before executing commands that might consume stdin.
+main "$@"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ artifacts = ["src/blocksd/web/static/**"]
 [tool.hatch.build.targets.sdist]
 include = [
     "/src", "/tests", "/web", "/systemd", "/docs",
-    "/LICENSE", "/README.md", "/pyproject.toml", "/uv.lock",
+    "/LICENSE", "/README.md", "/pyproject.toml", "/uv.lock", "/install.sh",
 ]
 artifacts = ["src/blocksd/web/static/**"]
 

--- a/src/blocksd/cli/install.py
+++ b/src/blocksd/cli/install.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import sys
 import textwrap
 from pathlib import Path
 
@@ -33,17 +35,25 @@ _SERVICE_PATH = _SERVICE_DIR / "blocksd.service"
 
 def _find_blocksd_bin() -> str:
     """Find the installed blocksd binary path."""
-    path = shutil.which("blocksd")
-    if path:
-        return path
-    # Fallback: common uv tool install location
-    candidate = Path.home() / ".local" / "bin" / "blocksd"
-    if candidate.exists():
-        return str(candidate)
-    return str(candidate)  # best guess
+    invoked = Path(sys.argv[0]).absolute()
+    candidates = [invoked] if invoked.name == "blocksd" else []
+    if path := shutil.which("blocksd"):
+        candidates.append(Path(path))
+    candidates.append(Path.home() / ".local" / "bin" / "blocksd")
+    for candidate in candidates:
+        if candidate.is_file() and os.access(candidate, os.X_OK):
+            return str(candidate)
+    raise FileNotFoundError("Cannot locate blocksd executable; add its install directory to PATH")
 
 
 def _generate_service(bin_path: str) -> str:
+    # systemd rejects quotes, backslashes and control characters in executable paths.
+    if any(char in bin_path for char in ('"', "'", "\\")) or any(
+        ord(char) < 32 or ord(char) == 127 for char in bin_path
+    ):
+        raise ValueError("systemd cannot use this executable path; install in a simpler directory")
+    # Specifiers expand in the executable, but environment variables only expand in arguments.
+    escaped = bin_path.replace("%", "%%")
     return textwrap.dedent(f"""\
         [Unit]
         Description=ROLI Blocks Device Manager
@@ -53,7 +63,7 @@ def _generate_service(bin_path: str) -> str:
 
         [Service]
         Type=notify
-        ExecStart={bin_path} run --daemon
+        ExecStart="{escaped}" run --daemon
         Restart=on-failure
         RestartSec=5
         WatchdogSec=30
@@ -75,26 +85,36 @@ def _run(cmd: list[str], *, sudo: bool = False, check: bool = True) -> bool:
     if sudo:
         cmd = ["sudo", *cmd]
     try:
-        subprocess.run(cmd, check=check)  # noqa: S603
-    except (subprocess.CalledProcessError, FileNotFoundError):
+        result = subprocess.run(cmd, check=check)  # noqa: S603
+    except (subprocess.CalledProcessError, OSError) as exc:
+        typer.echo(f"Command failed: {' '.join(cmd)}: {exc}", err=True)
+        if check:
+            raise typer.Exit(1) from exc
         return False
     else:
-        return True
+        return result.returncode == 0
 
 
 @app.command()
 def install(
     no_udev: bool = typer.Option(False, "--no-udev", help="Skip udev rules installation"),
     no_service: bool = typer.Option(False, "--no-service", help="Skip systemd service"),
-    no_enable: bool = typer.Option(False, "--no-enable", help="Don't enable the service"),
+    no_enable: bool = typer.Option(
+        False, "--no-enable", help="Write/reload the service without enabling or restarting"
+    ),
 ) -> None:
     """Install systemd user service and udev rules."""
-    if not no_udev:
-        _install_udev()
-    if not no_service:
-        _install_service(enable=not no_enable)
-    typer.echo()
-    typer.echo("Done! Start with: systemctl --user start blocksd")
+    try:
+        # Resolve before any privileged changes so a missing entrypoint fails early.
+        bin_path = _find_blocksd_bin() if not no_service else None
+        if not no_udev:
+            _install_udev()
+        if bin_path is not None:
+            _install_service(bin_path, enable=not no_enable)
+    except (OSError, ValueError) as exc:
+        typer.echo(f"Installation failed: {exc}", err=True)
+        raise typer.Exit(1) from exc
+    typer.echo("Installation complete.")
 
 
 @app.command()
@@ -126,28 +146,29 @@ def _install_udev() -> None:
     with tempfile.NamedTemporaryFile(mode="w", suffix=".rules", delete=False) as f:
         f.write(_UDEV_RULES)
         tmp = f.name
-    if _run(["cp", tmp, str(_UDEV_RULES_DEST)], sudo=True):
-        Path(tmp).unlink(missing_ok=True)
+    try:
+        _run(["install", "-m", "0644", tmp, str(_UDEV_RULES_DEST)], sudo=True)
         _run(["udevadm", "control", "--reload-rules"], sudo=True)
         _run(["udevadm", "trigger"], sudo=True)
         typer.echo(f"Installed {_UDEV_RULES_DEST}")
-    else:
+    finally:
         Path(tmp).unlink(missing_ok=True)
-        typer.echo("Failed to install udev rules", err=True)
 
 
-def _install_service(*, enable: bool = True) -> None:
+def _install_service(bin_path: str, *, enable: bool = True) -> None:
     """Install systemd user service."""
-    bin_path = _find_blocksd_bin()
     service_content = _generate_service(bin_path)
 
     _SERVICE_DIR.mkdir(parents=True, exist_ok=True)
     _SERVICE_PATH.write_text(service_content)
     typer.echo(f"Installed {_SERVICE_PATH}")
-    typer.echo(f"  ExecStart={bin_path} run --daemon")
+    typer.echo(f"  Executable: {bin_path}")
 
     _run(["systemctl", "--user", "daemon-reload"])
 
     if enable:
         _run(["systemctl", "--user", "enable", "blocksd"])
-        typer.echo("Service enabled (starts on login)")
+        _run(["systemctl", "--user", "restart", "blocksd"])
+        typer.echo("Service enabled and restarted (starts on login)")
+    else:
+        typer.echo("Service installed; enable/start/restart state unchanged")

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -1,0 +1,244 @@
+"""Installer behavior without touching host service or device configuration."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from blocksd.cli import install
+from blocksd.cli.app import app
+
+
+@pytest.fixture
+def setup_commands(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Mock:
+    monkeypatch.setattr(install, "_SERVICE_DIR", tmp_path)
+    monkeypatch.setattr(install, "_SERVICE_PATH", tmp_path / "blocksd.service")
+    monkeypatch.setattr(install, "_find_blocksd_bin", lambda: "/opt/my tools/blocksd")
+    commands = Mock(return_value=subprocess.CompletedProcess([], 0))
+    monkeypatch.setattr(install.subprocess, "run", commands)
+    return commands
+
+
+def test_service_starts_and_restarts_on_repeated_install(setup_commands: Mock) -> None:
+    for _ in range(2):
+        result = CliRunner().invoke(app, ["install", "--no-udev"])
+        assert result.exit_code == 0, result.output
+    commands = [call.args[0] for call in setup_commands.call_args_list]
+    assert (
+        commands
+        == [
+            ["systemctl", "--user", "daemon-reload"],
+            ["systemctl", "--user", "enable", "blocksd"],
+            ["systemctl", "--user", "restart", "blocksd"],
+        ]
+        * 2
+    )
+    assert 'ExecStart="/opt/my tools/blocksd" run --daemon' in install._SERVICE_PATH.read_text()
+
+
+def test_no_enable_does_not_restart_or_enable(setup_commands: Mock) -> None:
+    result = CliRunner().invoke(app, ["install", "--no-udev", "--no-enable"])
+    assert result.exit_code == 0, result.output
+    setup_commands.assert_called_once_with(["systemctl", "--user", "daemon-reload"], check=True)
+
+
+def test_no_service_skips_executable_lookup(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(install, "_find_blocksd_bin", Mock(side_effect=AssertionError))
+    result = CliRunner().invoke(app, ["install", "--no-udev", "--no-service"])
+    assert result.exit_code == 0, result.output
+
+
+@pytest.mark.parametrize("failed_step", ["daemon-reload", "enable", "restart"])
+def test_service_errors_fail_install(setup_commands: Mock, failed_step: str) -> None:
+    def run(command: list[str], *, check: bool) -> subprocess.CompletedProcess:
+        if failed_step in command:
+            raise subprocess.CalledProcessError(1, command)
+        return subprocess.CompletedProcess(command, 0)
+
+    setup_commands.side_effect = run
+    result = CliRunner().invoke(app, ["install", "--no-udev"])
+    assert result.exit_code == 1
+    assert "Command failed" in result.output
+    assert "Installation complete" not in result.output
+
+
+def test_failed_udev_copy_cleans_temp_file(setup_commands: Mock) -> None:
+    setup_commands.side_effect = subprocess.CalledProcessError(1, ["sudo", "install"])
+    result = CliRunner().invoke(app, ["install", "--no-service"])
+    assert result.exit_code == 1
+    assert "Installation complete" not in result.output
+    command = setup_commands.call_args.args[0]
+    assert command[:4] == ["sudo", "install", "-m", "0644"]
+    assert not Path(command[4]).exists()
+
+
+def test_missing_binary_fails_before_udev(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        install, "_find_blocksd_bin", Mock(side_effect=FileNotFoundError("missing"))
+    )
+    udev = Mock()
+    monkeypatch.setattr(install, "_install_udev", udev)
+    result = CliRunner().invoke(app, ["install"])
+    assert result.exit_code == 1
+    udev.assert_not_called()
+
+
+def test_find_binary_prefers_invoked_install(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    binary = tmp_path / "blocksd"
+    binary.write_text("#!/bin/sh\n")
+    binary.chmod(0o755)
+    monkeypatch.setattr(install.sys, "argv", [str(binary)])
+    monkeypatch.setattr(install.shutil, "which", lambda _: "/other/blocksd")
+    assert install._find_blocksd_bin() == str(binary)
+
+
+def test_find_binary_never_returns_nonexistent_guess(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    monkeypatch.setattr(install.sys, "argv", ["pytest"])
+    monkeypatch.setattr(install.shutil, "which", lambda _: None)
+    monkeypatch.setattr(install.Path, "home", lambda: tmp_path)
+    with pytest.raises(FileNotFoundError):
+        install._find_blocksd_bin()
+
+
+def test_service_escapes_specifiers_but_preserves_literal_dollar() -> None:
+    content = install._generate_service("/opt/a %h $HOME/blocksd")
+    assert 'ExecStart="/opt/a %%h $HOME/blocksd" run --daemon' in content
+
+
+@pytest.mark.parametrize("path", ['/opt/a"b/blocksd', "/opt/a\\b/blocksd", "/opt/a\nb/blocksd"])
+def test_service_rejects_unsupported_executable_paths(path: str) -> None:
+    with pytest.raises(ValueError, match="systemd cannot use"):
+        install._generate_service(path)
+
+
+@pytest.fixture
+def shell_env(tmp_path: Path) -> dict[str, str]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    tool_dir = tmp_path / "tool bin"
+    tool_dir.mkdir()
+    scripts = {
+        "id": "printf '1000\\n'",
+        "uname": "printf 'Linux\\n'",
+        "uv": (
+            'printf "uv:%s\\n" "$*" >> "$INSTALL_LOG"\n'
+            'if [ "$*" = "tool dir --bin" ]; then printf "%s\\n" "$TOOL_BIN"; fi\n'
+            'if [ "${UV_FAIL:-0}" = 1 ]; then exit 8; fi'
+        ),
+    }
+    for name, source in scripts.items():
+        binary = bin_dir / name
+        binary.write_text("#!/bin/sh\n" + source + "\n")
+        binary.chmod(0o755)
+    binary = tool_dir / "blocksd"
+    binary.write_text(
+        '#!/bin/sh\nprintf "blocksd:%s\\n" "$*" >> "$INSTALL_LOG"\nexit "${SETUP_EXIT:-0}"\n'
+    )
+    binary.chmod(0o755)
+    return {
+        **os.environ,
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "HOME": str(tmp_path),
+        "INSTALL_LOG": str(tmp_path / "commands"),
+        "TOOL_BIN": str(tool_dir),
+    }
+
+
+def run_installer(env: dict[str, str], *args: str) -> subprocess.CompletedProcess[str]:
+    # stdin simulates curl | bash; setup must never read script content as a prompt.
+    return subprocess.run(  # noqa: S603
+        ["/bin/bash", "-s", "--", *args],
+        input=Path("install.sh").read_text(),
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def test_piped_installer_upgrades_and_forwards_options(shell_env: dict[str, str]) -> None:
+    result = run_installer(shell_env, "--version", "0.5.0", "--no-udev", "--no-enable")
+    assert result.returncode == 0, result.stderr
+    commands = Path(shell_env["INSTALL_LOG"]).read_text().splitlines()
+    assert commands == [
+        "uv:tool install --python 3.13 --managed-python --upgrade blocksd==0.5.0",
+        "uv:tool dir --bin",
+        "blocksd:install --no-udev --no-enable",
+    ]
+    assert "Installed:" in result.stdout
+
+
+@pytest.mark.parametrize("env_change", [{"UV_FAIL": "1"}, {"SETUP_EXIT": "9"}])
+def test_shell_failures_are_not_reported_as_success(
+    shell_env: dict[str, str], env_change: dict[str, str]
+) -> None:
+    result = run_installer({**shell_env, **env_change}, "--no-udev", "--no-service")
+    assert result.returncode != 0
+    assert "Installed:" not in result.stdout
+
+
+@pytest.mark.parametrize("args", [("--version",), ("--version", "--evil"), ("--bogus",)])
+def test_shell_rejects_bad_options_before_install(
+    shell_env: dict[str, str], args: tuple[str, ...]
+) -> None:
+    result = run_installer(shell_env, *args)
+    assert result.returncode == 2
+    assert not Path(shell_env["INSTALL_LOG"]).exists()
+
+
+@pytest.fixture
+def bootstrap_env(shell_env: dict[str, str]) -> dict[str, str]:
+    bin_dir = Path(shell_env["HOME"]) / "bin"
+    uv_source = (bin_dir / "uv").read_text()
+    (bin_dir / "uv").unlink()
+    for command in ("sh", "mktemp", "rm", "mkdir", "cp", "chmod"):
+        (bin_dir / command).symlink_to(Path("/usr/bin") / command)
+    source = bin_dir / "uv-source"
+    source.write_text(uv_source)
+    source.chmod(0o755)
+    bootstrap = bin_dir / "bootstrap"
+    bootstrap.write_text(
+        '#!/bin/sh\nmkdir -p "$UV_UNMANAGED_INSTALL"\n'
+        'cp "$HOME/bin/uv-source" "$UV_UNMANAGED_INSTALL/uv"\n'
+    )
+    curl = bin_dir / "curl"
+    curl.write_text('#!/bin/sh\nfor last; do :; done\ncp "$HOME/bin/bootstrap" "$last"\n')
+    curl.chmod(0o755)
+    temp_dir = Path(shell_env["HOME"]) / "bootstrap temp"
+    temp_dir.mkdir()
+    return {**shell_env, "PATH": str(bin_dir), "TMPDIR": str(temp_dir)}
+
+
+def test_bootstrap_without_uv_is_noninteractive(bootstrap_env: dict[str, str]) -> None:
+    result = run_installer(bootstrap_env, "--no-udev", "--no-service")
+    assert result.returncode == 0, result.stderr
+    assert "Installing uv" in result.stdout
+    assert (Path(bootstrap_env["HOME"]) / ".local/bin/uv").is_file()
+    assert (
+        "blocksd:install --no-udev --no-service" in Path(bootstrap_env["INSTALL_LOG"]).read_text()
+    )
+    assert not list(Path(bootstrap_env["TMPDIR"]).iterdir())
+
+
+@pytest.mark.parametrize("failed_command", ["curl", "bootstrap"])
+def test_bootstrap_failure_preserves_status_and_cleans_download(
+    bootstrap_env: dict[str, str], failed_command: str
+) -> None:
+    command = Path(bootstrap_env["HOME"]) / "bin" / failed_command
+    command.write_text("#!/bin/sh\nprintf 'bootstrap failure\\n' >&2\nexit 17\n")
+    result = run_installer(bootstrap_env, "--no-udev", "--no-service")
+    assert result.returncode == 17
+    assert "bootstrap failure" in result.stderr
+    assert "unbound variable" not in result.stderr
+    assert "Installed:" not in result.stdout
+    assert not Path(bootstrap_env["INSTALL_LOG"]).exists()
+    assert not list(Path(bootstrap_env["TMPDIR"]).iterdir())


### PR DESCRIPTION
Installing or upgrading blocksd now uses uv with managed Python 3.13 and the CLI's shared service setup. Re-running the installer upgrades the package and restarts the service; explicit flags skip udev, service setup, or activation. Failed setup commands return a failure status, and bootstrap failures retain their original error while cleaning temporary files.

Release downloads include the wheel, source archive, installer, and SHA256 checksums. PyPI receives only package distributions. The GitHub release workflow generates notes through git-iris with Anthropic `claude-opus-5`.

The documentation now describes current commands, API payloads, architecture, and upgrade steps. It also explains two existing hardware limitations: the daemon does not upload the LittleFoot LED renderer, and standalone LED/config/probe commands open separate MIDI sessions.

## 🧪 Validation

The complete `just check` passes, including 446 Python tests, dashboard and docs builds, and an isolated installed-wheel smoke test. Independent adversarial verification also passed fresh source-to-wheel packaging, piped installer upgrades, bootstrap failure cleanup, and release checksum preparation. ShellCheck, Bash syntax, and actionlint pass.

Live PyPI publication and release downloads will be verified after the versioned release workflow runs.
