### PR TITLE
feat(macos): support CoreMIDI and per-user LaunchAgents

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
       - run: uv lock --check
       - run: uv build --clear
       - name: Verify installed distribution
-        run: uv run --no-project --with dist/*.whl python scripts/check_distribution.py
+        run: uv run --no-project --no-cache --with dist/*.whl python scripts/check_distribution.py
 
   docs:
     name: Documentation

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,17 @@ permissions:
 
 jobs:
   python:
-    name: Python ${{ matrix.python-version }}
-    runs-on: ubuntu-latest
+    name: Python ${{ matrix.python-version }} (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest, macos-latest]
         python-version: ["3.13", "3.14"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev
+      - if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.10"
@@ -35,14 +37,19 @@ jobs:
       - run: uv run --locked pytest
 
   web:
-    name: Dashboard and distribution
-    runs-on: ubuntu-latest
+    name: Dashboard and distribution (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: ./.github/actions/setup-js
       - run: pnpm --dir web check
       - run: pnpm --dir web build
-      - run: sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev
+      - if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y libasound2-dev libjack-jackd2-dev
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
           version: "0.12.10"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ The RtMidi extension needs native development headers when a wheel is unavailabl
 sudo apt-get install build-essential pkg-config libasound2-dev libjack-jackd2-dev
 ```
 
+On macOS, install Xcode Command Line Tools (`xcode-select --install`) if RtMidi needs to compile. macOS uses CoreMIDI and does not require ALSA/JACK headers. Python tests and installed-wheel checks run on both Linux and macOS in CI.
+
 Clone the repository and install the locked dependencies:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </h1>
 
 <p align="center">
-  <strong>Linux Daemon for ROLI Blocks Devices</strong><br>
+  <strong>Linux and macOS Daemon for ROLI Blocks Devices</strong><br>
   <sub>✦ Topology · Keepalive · LED Control · Touch Events ✦</sub>
 </p>
 
@@ -32,7 +32,7 @@
 
 ROLI Blocks devices need an active host-side handshake over MIDI SysEx to enter "API mode." Without it, they show a searching animation and eventually power off. There's no official Linux support.
 
-**blocksd** implements the ROLI Blocks host protocol: device discovery, topology management, API mode keepalive, LED control, touch events, and device configuration. Your Blocks stay alive and useful on Linux.
+**blocksd** implements the ROLI Blocks host protocol: device discovery, topology management, API mode keepalive, LED control, touch events, and device configuration. The shared runtime uses ALSA on Linux and CoreMIDI on macOS.
 
 ## ✦ Features
 
@@ -49,6 +49,23 @@ ROLI Blocks devices need an active host-side handshake over MIDI SysEx to enter 
 
 ## 📦 Install
 
+### macOS
+
+macOS support is available from source until the next release. Build the dashboard, then run in the foreground:
+
+```bash
+git clone https://github.com/hyperb1iss/blocksd.git
+cd blocksd
+uv sync --locked
+pnpm --dir web install --frozen-lockfile
+pnpm --dir web build
+uv run --locked blocksd run -v
+```
+
+After stopping the foreground process, run `uv run --locked blocksd install` to install a per-user LaunchAgent that starts on login. macOS does not need udev rules or sudo. Keep the checkout and its virtual environment at the installed path.
+
+The macOS runtime and installer have automated coverage. Hardware handshake, sleep/wake, and DAW coexistence still need validation with connected Blocks. See the [macOS installation guide](https://hyperb1iss.github.io/blocksd/guide/installation#macos) for service commands and the hardware checklist.
+
 ### Quick Install
 
 ```bash
@@ -56,7 +73,7 @@ curl -fsSL https://github.com/hyperb1iss/blocksd/releases/latest/download/instal
 bash install-blocksd.sh
 ```
 
-Installs or upgrades blocksd using uv and managed Python, installs udev rules with sudo, and enables and restarts a systemd user service. Run as your normal user. Use `--version 0.5.0` to select a release or `--no-udev`, `--no-service`, and `--no-enable` to skip setup steps. See the [installation guide](https://hyperb1iss.github.io/blocksd/guide/installation) for prerequisites and upgrade details.
+The current release installer targets Linux. It installs or upgrades blocksd using uv and managed Python, installs udev rules with sudo, and enables and restarts a systemd user service. Run as your normal user. Use `--version 0.5.0` to select a release or `--no-udev`, `--no-service`, and `--no-enable` to skip setup steps. See the [installation guide](https://hyperb1iss.github.io/blocksd/guide/installation) for prerequisites and upgrade details.
 
 ### From PyPI
 
@@ -178,6 +195,7 @@ blocksd uninstall                      # remove service and udev rules
 
 - Socket path: `$XDG_RUNTIME_DIR/blocksd/blocksd.sock`
 - Fallback path: `/tmp/blocksd/blocksd.sock`
+- macOS path: `/tmp/blocksd-<uid>/blocksd.sock` in a private per-user directory
 - One socket supports both control messages and high-rate LED frame writes
 
 **WebSocket**: browser and network clients (used by `blocksd ui`)

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -17,6 +17,8 @@ Only the first existing file is loaded; user and system settings are not merged.
 blocksd run --config /path/to/config.toml
 ```
 
+On macOS, `~/Library/Application Support/blocksd/config.toml` takes priority over the two paths above. Existing `~/.config/blocksd/config.toml` files remain usable as a fallback.
+
 ## Example Configuration
 
 All settings live under a `[daemon]` section. Here's a fully annotated example showing every field at its default value:
@@ -56,7 +58,7 @@ The schema accepts `scan_interval`, `ping_interval_master`, `ping_interval_dna`,
 
 **`api_enabled`** controls whether the Unix socket server starts with the daemon. When enabled, external clients can connect to discover devices, stream LED frames, and subscribe to touch/button events.
 
-**`api_socket`** overrides the socket path. By default, blocksd creates the socket at `$XDG_RUNTIME_DIR/blocksd/blocksd.sock`, falling back to `/tmp/blocksd/blocksd.sock` if `XDG_RUNTIME_DIR` is not set.
+**`api_socket`** overrides the socket path. On Linux, blocksd creates the socket at `$XDG_RUNTIME_DIR/blocksd/blocksd.sock`, falling back to `/tmp/blocksd/blocksd.sock` if `XDG_RUNTIME_DIR` is not set. On macOS, the default is `/tmp/blocksd-<uid>/blocksd.sock` in a directory owned by the current user with mode `0700`. A short path avoids the Unix socket address limit even when macOS provides a long temporary directory path.
 
 ### Web Dashboard
 
@@ -81,7 +83,7 @@ blocksd ui --no-browser          # start server without opening browser
 
 ## Environment Variables
 
-blocksd respects standard Linux environment variables for path resolution:
+On Linux, blocksd respects the runtime directory environment variable below. macOS uses the per-user socket path described above instead.
 
 | Variable          | Default | Used For              |
 | ----------------- | ------- | --------------------- |

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -1,8 +1,58 @@
 # Installation
 
-blocksd runs on Linux with ALSA MIDI, Python 3.13 or newer, and a systemd user session for service management. The quick installer provides uv and a managed Python when needed.
+blocksd uses ALSA MIDI on Linux and CoreMIDI on macOS, with Python 3.13 or newer. Background startup uses a systemd user service on Linux and a per-user LaunchAgent on macOS. Windows support is not implemented.
+
+## macOS
+
+macOS support is available from source until the next release. Follow [From Source](#from-source), or build only the runtime and dashboard:
+
+```bash
+git clone https://github.com/hyperb1iss/blocksd.git
+cd blocksd
+uv sync --locked
+pnpm --dir web install --frozen-lockfile
+pnpm --dir web build
+uv run --locked blocksd status
+uv run --locked blocksd run -v
+```
+
+Stop the foreground process before installing the background service:
+
+```bash
+uv run --locked blocksd install
+launchctl print "gui/$(id -u)/tech.hyperbliss.blocksd"
+tail -n 30 "$HOME/Library/Logs/blocksd/stderr.log"
+```
+
+Installation requires a GUI login session and creates `~/Library/LaunchAgents/tech.hyperbliss.blocksd.plist`. The agent starts on login, restarts after a failed exit, and writes logs under `~/Library/Logs/blocksd/`. Re-running installation unloads the previous registration and starts the current executable. The service uses an absolute executable path, so keep the checkout and virtual environment in place.
+
+Use `blocksd install --no-enable` to write the plist without changing the running service. The `--no-service` option skips service setup entirely. macOS ignores `--no-udev`; no device permission rules or sudo are needed. Use the `uv run --locked` prefix for commands in a source checkout.
+
+To stop the service before probing hardware or running standalone LED/config commands:
+
+```bash
+launchctl bootout "gui/$(id -u)/tech.hyperbliss.blocksd"
+uv run --locked blocksd status --probe
+uv run --locked blocksd install
+```
+
+Open `http://localhost:9010` while the daemon runs. User configuration lives at `~/Library/Application Support/blocksd/config.toml`. The Unix socket is `/tmp/blocksd-<uid>/blocksd.sock` (replace `<uid>` with `id -u`); its parent must be owned by the current user with mode `0700`.
+
+CoreMIDI scanning, runtime startup, and installer behavior can be checked without hardware. Before treating a Mac/device combination as hardware-validated, check:
+
+- Serial and topology responses during `status --probe`, followed by sustained API keepalive.
+- Touch/button events and configuration reads with the daemon running.
+- USB unplug/replug and DNA topology changes, including two identical Blocks.
+- Recovery after sleep/wake.
+- Concurrent MIDI use with your DAW. Close ROLI Dashboard during the protocol check so another host does not change API mode.
+
+Hardware acceptance remains pending. The existing LittleFoot renderer limitation also applies on macOS: accepted LED writes do not prove visible output.
+
+If python-rtmidi builds from source, install Xcode Command Line Tools (`xcode-select --install`). CoreMIDI is the native backend; ALSA/JACK packages are not needed.
 
 ## Quick Install and Upgrade
+
+The current published release installer targets Linux. Use the source instructions above for macOS until a release includes the new installer.
 
 Download the release installer, inspect it, and run it as your normal user:
 
@@ -62,7 +112,7 @@ uv run --locked blocksd install
 
 Keep the checkout and its virtual environment at that path while the service uses it. After updating the checkout, sync dependencies, rebuild the dashboard, and rerun `uv run --locked blocksd install` to restart the service.
 
-## What Service Setup Does
+## Linux Service Setup
 
 The udev file at `/etc/udev/rules.d/99-roli-blocks.rules` grants all local users read/write access to matching ROLI devices (`MODE="0666"`) and adds the `uaccess` tag. Installation requires sudo. Reconnect your devices after installing the rules.
 
@@ -87,7 +137,7 @@ Open `http://localhost:9010` for the running daemon's dashboard. Do not launch `
 
 The `status --probe`, `led`, and `config` commands open separate MIDI sessions. Stop the service before using those commands, then restart it afterward.
 
-## Native Dependencies
+## Linux Native Dependencies
 
 ALSA runtime support is required. If python-rtmidi needs to compile from source, install a C/C++ toolchain, pkg-config, and ALSA/JACK development headers. For Debian or Ubuntu:
 
@@ -100,7 +150,7 @@ Use the equivalent development packages for your distribution. The installer doe
 ## Uninstall
 
 ```bash
-blocksd uninstall               # service and udev rules
+blocksd uninstall               # native service (plus udev rules on Linux)
 uv tool uninstall blocksd       # Python package (uv installations)
 ```
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -8,8 +8,9 @@ blocksd exposes two APIs for building your own integrations: a Unix domain socke
 
 Low-latency local IPC. This is the preferred method for local integrations.
 
-- Primary path: `$XDG_RUNTIME_DIR/blocksd/blocksd.sock`
-- Fallback path: `/tmp/blocksd/blocksd.sock`
+- Linux primary path: `$XDG_RUNTIME_DIR/blocksd/blocksd.sock`
+- Linux fallback path: `/tmp/blocksd/blocksd.sock`
+- macOS path: `/tmp/blocksd-<uid>/blocksd.sock`, using the current user's numeric ID
 - Permissions: directory `0700`, socket `0660`
 
 ### WebSocket

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -136,25 +136,27 @@ blocksd config set 10 50         # set velocity sensitivity to 50
 
 ## `blocksd install`
 
-Set up systemd service and udev rules. The udev rule installation requires sudo.
+Set up a systemd user service and udev rules on Linux, or a per-user LaunchAgent on macOS. Only Linux udev installation requires sudo. macOS service registration requires a GUI login session.
 
 ```bash
-blocksd install                  # full setup (udev + systemd + auto-start)
+blocksd install                  # native service + auto-start, plus Linux udev rules
 blocksd install --no-udev        # skip udev rules
-blocksd install --no-enable      # write/reload service without enabling or restarting
-blocksd install --no-service     # skip systemd service entirely
+blocksd install --no-enable      # write service without enabling or restarting
+blocksd install --no-service     # skip background service setup entirely
 ```
 
-This creates:
+The Linux installer creates:
 
 | File                                     | Purpose                              |
 | ---------------------------------------- | ------------------------------------ |
 | `/etc/udev/rules.d/99-roli-blocks.rules` | USB device permissions for your user |
 | `~/.config/systemd/user/blocksd.service` | systemd user service with watchdog   |
 
+The macOS installer creates `~/Library/LaunchAgents/tech.hyperbliss.blocksd.plist` and writes logs under `~/Library/Logs/blocksd/`. Repeated installation replaces the loaded service definition and starts the new executable. With `--no-enable`, macOS only writes the definition; Linux also reloads systemd. See [macOS installation](../guide/installation#macos) for stop, start, and status commands.
+
 ## `blocksd uninstall`
 
-Remove the systemd service and udev rules. The Python package and user configuration remain; remove a uv tool installation separately with `uv tool uninstall blocksd`.
+Remove the native background service and, on Linux, udev rules. The Python package, user configuration, and macOS logs remain; remove a uv tool installation separately with `uv tool uninstall blocksd`.
 
 ```bash
 blocksd uninstall

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Install or upgrade blocksd and configure Linux device/service integration.
+# Install or upgrade blocksd and configure native device/service integration.
 set -euo pipefail
 
 bootstrap_uv() (
@@ -28,13 +28,14 @@ main() {
 Usage: bash install.sh [--version VERSION] [--no-udev] [--no-service] [--no-enable]
 
 Install or upgrade blocksd using uv and managed Python 3.13.
-By default install udev rules (sudo), enable the user service, and restart it.
+By default enable and restart the user service; Linux also installs udev rules (sudo).
   --version VERSION  Install a specific PyPI version (default: latest)
   --no-udev          Skip device permission rules (no sudo needed)
-  --no-service       Skip all systemd setup
-  --no-enable        Write/reload service without enabling or restarting it
-Run as your normal user. Requires Linux, curl, and a systemd user session
-unless --no-service is used. Re-running upgrades the package and restarts it.
+  --no-service       Skip all background service setup
+  --no-enable        Write service without enabling or restarting (Linux reloads)
+Run as your normal user. Requires Linux or macOS and curl for uv bootstrap.
+Service setup requires a systemd user session on Linux or a GUI login on macOS.
+Re-running upgrades the package and restarts the service.
 HELP
                 return 0
                 ;;
@@ -42,7 +43,10 @@ HELP
         esac
     done
 
-    [[ "$(uname -s)" == Linux ]] || { printf 'blocksd requires Linux\n' >&2; return 1; }
+    case "$(uname -s)" in
+        Linux|Darwin) ;;
+        *) printf 'This installer supports Linux and macOS only\n' >&2; return 1 ;;
+    esac
     [[ "$(id -u)" != 0 ]] || { printf 'Run as your normal user, without sudo\n' >&2; return 1; }
     uv_bin=$(command -v uv || true)
     if [[ -z "$uv_bin" ]]; then

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ build: web-build
 
 # Use an isolated environment to prove the wheel works without the checkout
 build-check: build
-    uv run --no-project --with dist/*.whl python scripts/check_distribution.py
+    uv run --no-project --no-cache --with dist/*.whl python scripts/check_distribution.py
 
 # Clean Python artifacts; JavaScript build commands replace their own output
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,18 +1,19 @@
 [project]
 name = "blocksd"
 version = "0.5.0"
-description = "Linux daemon for ROLI Blocks devices — keeps them alive, controls LEDs, manages topology"
+description = "ROLI Blocks daemon for Linux and macOS: keepalive, LED control, and topology"
 readme = "README.md"
 license = "ISC"
 requires-python = ">=3.13"
 authors = [{ name = "Stefanie Jane", email = "stef@hyperbliss.tech" }]
-keywords = ["roli", "blocks", "midi", "lightpad", "seaboard", "linux", "daemon"]
+keywords = ["roli", "blocks", "midi", "lightpad", "seaboard", "linux", "macos", "daemon"]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Environment :: Console",
     "Intended Audience :: End Users/Desktop",
     "License :: OSI Approved :: ISC License (ISCL)",
     "Operating System :: POSIX :: Linux",
+    "Operating System :: MacOS :: MacOS X",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
     "Topic :: Multimedia :: Sound/Audio :: MIDI",

--- a/src/blocksd/api/server.py
+++ b/src/blocksd/api/server.py
@@ -13,8 +13,8 @@ import json
 import logging
 import os
 import stat
+import sys
 import time
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from blocksd.api.commands import ApiCommands
@@ -25,22 +25,16 @@ from blocksd.api.protocol import (
     encode_json,
 )
 from blocksd.api.websocket import WSOpcode, build_frame, read_frame
+from blocksd.paths import default_socket_path
 from blocksd.web import resolve_static_dir
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Coroutine
+    from pathlib import Path
 
     from blocksd.topology.manager import TopologyManager
 
 log = logging.getLogger(__name__)
-
-
-def default_socket_path() -> Path:
-    """Default socket path: $XDG_RUNTIME_DIR/blocksd/blocksd.sock."""
-    runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-    if runtime_dir:
-        return Path(runtime_dir) / "blocksd" / "blocksd.sock"
-    return Path("/tmp/blocksd/blocksd.sock")
 
 
 class _ApiTransport(ApiCommands):
@@ -111,6 +105,7 @@ class ApiServer(_ApiTransport):
     ) -> None:
         super().__init__(manager)
         self._socket_path = socket_path or default_socket_path()
+        self._private_runtime = socket_path is None and sys.platform == "darwin"
         self._start_time = time.monotonic()
         self._client_count = 0
         self._socket_identity: tuple[int, int] | None = None
@@ -121,6 +116,16 @@ class ApiServer(_ApiTransport):
             return
         # Ensure socket directory exists
         self._socket_path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if self._private_runtime:
+            directory = self._socket_path.parent.lstat()
+            if (
+                not stat.S_ISDIR(directory.st_mode)
+                or directory.st_uid != os.getuid()
+                or stat.S_IMODE(directory.st_mode) & 0o077
+            ):
+                raise PermissionError(
+                    f"Socket directory must be private and owned by this user: {self._socket_path.parent}"
+                )
 
         # Only reclaim an actual socket whose previous listener is gone.
         if self._socket_path.exists():

--- a/src/blocksd/cli/app.py
+++ b/src/blocksd/cli/app.py
@@ -6,7 +6,7 @@ import typer
 
 app = typer.Typer(
     name="blocksd",
-    help="ROLI Blocks device manager for Linux",
+    help="ROLI Blocks device manager for Linux and macOS",
     no_args_is_help=True,
 )
 

--- a/src/blocksd/cli/install.py
+++ b/src/blocksd/cli/install.py
@@ -1,4 +1,4 @@
-"""Install/uninstall blocksd systemd service and udev rules."""
+"""Install/uninstall native user services and Linux device permissions."""
 
 from __future__ import annotations
 
@@ -42,7 +42,7 @@ def _find_blocksd_bin() -> str:
     candidates.append(Path.home() / ".local" / "bin" / "blocksd")
     for candidate in candidates:
         if candidate.is_file() and os.access(candidate, os.X_OK):
-            return str(candidate)
+            return str(candidate.absolute())
     raise FileNotFoundError("Cannot locate blocksd executable; add its install directory to PATH")
 
 
@@ -98,20 +98,28 @@ def _run(cmd: list[str], *, sudo: bool = False, check: bool = True) -> bool:
 @app.command()
 def install(
     no_udev: bool = typer.Option(False, "--no-udev", help="Skip udev rules installation"),
-    no_service: bool = typer.Option(False, "--no-service", help="Skip systemd service"),
+    no_service: bool = typer.Option(False, "--no-service", help="Skip background service setup"),
     no_enable: bool = typer.Option(
-        False, "--no-enable", help="Write/reload the service without enabling or restarting"
+        False, "--no-enable", help="Write service without enabling or restarting (Linux reloads)"
     ),
 ) -> None:
-    """Install systemd user service and udev rules."""
+    """Install a Linux systemd service or macOS LaunchAgent."""
+    _check_platform()
     try:
         # Resolve before any privileged changes so a missing entrypoint fails early.
         bin_path = _find_blocksd_bin() if not no_service else None
-        if not no_udev:
+        if sys.platform == "linux" and not no_udev:
             _install_udev()
         if bin_path is not None:
-            _install_service(bin_path, enable=not no_enable)
-    except (OSError, ValueError) as exc:
+            if sys.platform == "darwin":
+                from blocksd.cli.launchd import install_agent
+
+                install_agent(bin_path, enable=not no_enable)
+            else:
+                _install_service(bin_path, enable=not no_enable)
+    except typer.Exit:
+        raise
+    except (OSError, ValueError, RuntimeError) as exc:
         typer.echo(f"Installation failed: {exc}", err=True)
         raise typer.Exit(1) from exc
     typer.echo("Installation complete.")
@@ -119,7 +127,18 @@ def install(
 
 @app.command()
 def uninstall() -> None:
-    """Remove systemd service and udev rules."""
+    """Remove the native user service and Linux device permissions."""
+    _check_platform()
+    if sys.platform == "darwin":
+        from blocksd.cli.launchd import uninstall_agent
+
+        try:
+            uninstall_agent()
+        except (OSError, RuntimeError) as exc:
+            typer.echo(f"Uninstallation failed: {exc}", err=True)
+            raise typer.Exit(1) from exc
+        typer.echo("blocksd uninstalled.")
+        return
     _run(["systemctl", "--user", "stop", "blocksd"], check=False)
     _run(["systemctl", "--user", "disable", "blocksd"], check=False)
 
@@ -136,6 +155,12 @@ def uninstall() -> None:
         typer.echo("Removed udev rules")
 
     typer.echo("blocksd uninstalled.")
+
+
+def _check_platform() -> None:
+    if sys.platform not in {"linux", "darwin"}:
+        typer.echo("Service installation supports Linux and macOS only.", err=True)
+        raise typer.Exit(1)
 
 
 def _install_udev() -> None:

--- a/src/blocksd/cli/launchd.py
+++ b/src/blocksd/cli/launchd.py
@@ -1,0 +1,90 @@
+"""Per-user macOS LaunchAgent installation."""
+
+from __future__ import annotations
+
+import os
+import plistlib
+import subprocess
+import time
+from pathlib import Path
+
+import typer
+
+LABEL = "tech.hyperbliss.blocksd"
+_SERVICE_NOT_FOUND = 113
+_UNLOAD_TIMEOUT = 35.0
+
+
+def _launchctl(*args: str, allow_absent: bool = False) -> bool:
+    command = ["launchctl", *args]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)  # noqa: S603
+    if result.returncode == 0:
+        return True
+    if allow_absent and result.returncode == _SERVICE_NOT_FOUND:
+        return False
+    detail = result.stderr.strip() or result.stdout.strip()
+    raise RuntimeError(f"{' '.join(command)} failed ({result.returncode}): {detail}")
+
+
+def _plist_path() -> Path:
+    return Path.home() / "Library" / "LaunchAgents" / f"{LABEL}.plist"
+
+
+def _unload(target: str) -> None:
+    if not _launchctl("print", target, allow_absent=True):
+        return
+    _launchctl("bootout", target)
+    # bootout initiates teardown; launchd can retain the job while it exits.
+    deadline = time.monotonic() + _UNLOAD_TIMEOUT
+    while _launchctl("print", target, allow_absent=True):
+        if time.monotonic() >= deadline:
+            raise RuntimeError(f"Timed out waiting for launchd to unload {target}")
+        time.sleep(0.05)
+
+
+def _generate_plist(bin_path: str) -> bytes:
+    if not Path(bin_path).is_absolute():
+        raise ValueError("LaunchAgent executable path must be absolute")
+    logs = Path.home() / "Library" / "Logs" / "blocksd"
+    return plistlib.dumps(
+        {
+            "Label": LABEL,
+            "ProgramArguments": [bin_path, "run", "--daemon"],
+            "RunAtLoad": True,
+            "KeepAlive": {"SuccessfulExit": False},
+            "StandardOutPath": str(logs / "stdout.log"),
+            "StandardErrorPath": str(logs / "stderr.log"),
+        }
+    )
+
+
+def install_agent(bin_path: str, *, enable: bool) -> None:
+    """Write the agent and optionally replace its running registration."""
+    content = _generate_plist(bin_path)
+    path = _plist_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    (Path.home() / "Library" / "Logs" / "blocksd").mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(0o644)
+    typer.echo(f"Installed {path}")
+    typer.echo(f"  Executable: {bin_path}")
+    if not enable:
+        typer.echo("LaunchAgent written; active service state unchanged")
+        return
+    domain = f"gui/{os.getuid()}"
+    target = f"{domain}/{LABEL}"
+    _unload(target)
+    _launchctl("enable", target)
+    _launchctl("bootstrap", domain, str(path))
+    _launchctl("kickstart", target)
+    typer.echo("LaunchAgent enabled and started (starts on login)")
+
+
+def uninstall_agent() -> None:
+    """Unload the service before removing its definition; keep user logs."""
+    target = f"gui/{os.getuid()}/{LABEL}"
+    _unload(target)
+    path = _plist_path()
+    if path.exists():
+        path.unlink()
+        typer.echo(f"Removed {path}")

--- a/src/blocksd/config/loader.py
+++ b/src/blocksd/config/loader.py
@@ -6,7 +6,8 @@ import logging
 import tomllib
 from typing import TYPE_CHECKING
 
-from blocksd.config.schema import DEFAULT_CONFIG_PATHS, DaemonConfig
+from blocksd.config.schema import DaemonConfig
+from blocksd.paths import config_paths
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -17,12 +18,12 @@ log = logging.getLogger(__name__)
 def load_config(path: Path | None = None) -> DaemonConfig:
     """Load config from file, falling back to defaults.
 
-    Search order: explicit path → ~/.config/blocksd/config.toml → /etc/blocksd/config.toml
+    An explicit path takes priority over platform-specific defaults.
     """
     if path and path.exists():
         return _parse_config(path)
 
-    for candidate in reversed(DEFAULT_CONFIG_PATHS):
+    for candidate in config_paths():
         if candidate.exists():
             return _parse_config(candidate)
 

--- a/src/blocksd/config/schema.py
+++ b/src/blocksd/config/schema.py
@@ -2,8 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
-
 from pydantic import BaseModel
 
 
@@ -18,15 +16,9 @@ class DaemonConfig(BaseModel):
 
     # API server settings
     api_enabled: bool = True
-    api_socket: str = ""  # empty = default ($XDG_RUNTIME_DIR/blocksd/blocksd.sock)
+    api_socket: str = ""  # empty = platform-specific local socket path
 
     # Web UI settings
     web_enabled: bool = True
     web_host: str = "127.0.0.1"
     web_port: int = 9010
-
-
-DEFAULT_CONFIG_PATHS = [
-    Path("/etc/blocksd/config.toml"),
-    Path.home() / ".config" / "blocksd" / "config.toml",
-]

--- a/src/blocksd/device/connection.py
+++ b/src/blocksd/device/connection.py
@@ -108,7 +108,7 @@ class MidiConnection:
         return messages
 
     def close(self) -> None:
-        """Close both MIDI ports and release ALSA sequencer clients."""
+        """Close both MIDI ports and release native MIDI clients."""
         if self._closed:
             return
         self._closed = True
@@ -136,6 +136,7 @@ def open_connection(
     loop: asyncio.AbstractEventLoop,
     *,
     name: str = "",
+    endpoint_ids: tuple[int, int] | None = None,
 ) -> MidiConnection:
     """Open a MIDI input/output pair and return a MidiConnection."""
     import rtmidi
@@ -143,7 +144,27 @@ def open_connection(
     midi_in = rtmidi.MidiIn()
     midi_out = rtmidi.MidiOut()
 
-    midi_in.open_port(input_port)
-    midi_out.open_port(output_port)
+    try:
+        _validate_endpoints(input_port, output_port, endpoint_ids)
+        midi_in.open_port(input_port)
+        midi_out.open_port(output_port)
+        _validate_endpoints(input_port, output_port, endpoint_ids)
+        return MidiConnection(midi_in, midi_out, loop, name=name)
+    except Exception:
+        for port in (midi_in, midi_out):
+            with contextlib.suppress(Exception):
+                port.close_port()
+            with contextlib.suppress(Exception):
+                port.delete()
+        raise
 
-    return MidiConnection(midi_in, midi_out, loop, name=name)
+
+def _validate_endpoints(
+    input_port: int, output_port: int, expected: tuple[int, int] | None
+) -> None:
+    if expected is None:
+        return
+    from blocksd.device.coremidi import endpoint_ids
+
+    if endpoint_ids(input_port, output_port) != expected:
+        raise RuntimeError("CoreMIDI endpoints changed while opening ports")

--- a/src/blocksd/device/coremidi.py
+++ b/src/blocksd/device/coremidi.py
@@ -1,0 +1,84 @@
+"""Stable CoreMIDI endpoint identity alongside RtMidi's indexed port access."""
+
+from __future__ import annotations
+
+import ctypes
+import sys
+from dataclasses import dataclass
+from functools import cache
+
+_OBJECT_NOT_FOUND = -10842
+
+
+@dataclass(frozen=True)
+class CoreMidiEndpoint:
+    uid: int
+    entity: int
+
+
+@cache
+def _framework() -> tuple[ctypes.CDLL, ctypes.c_void_p]:
+    if sys.platform != "darwin":
+        raise RuntimeError("CoreMIDI endpoint discovery requires macOS")
+    library = ctypes.CDLL("/System/Library/Frameworks/CoreMIDI.framework/CoreMIDI")
+    for name in ("MIDIGetNumberOfSources", "MIDIGetNumberOfDestinations"):
+        function = getattr(library, name)
+        function.argtypes = []
+        function.restype = ctypes.c_ulong
+    for name in ("MIDIGetSource", "MIDIGetDestination"):
+        function = getattr(library, name)
+        function.argtypes = [ctypes.c_ulong]
+        function.restype = ctypes.c_uint32
+    library.MIDIObjectGetIntegerProperty.argtypes = [
+        ctypes.c_uint32,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_int32),
+    ]
+    library.MIDIObjectGetIntegerProperty.restype = ctypes.c_int32
+    library.MIDIEndpointGetEntity.argtypes = [ctypes.c_uint32, ctypes.POINTER(ctypes.c_uint32)]
+    library.MIDIEndpointGetEntity.restype = ctypes.c_int32
+    unique_id = ctypes.c_void_p.in_dll(library, "kMIDIPropertyUniqueID")
+    return library, unique_id
+
+
+def _read_endpoint(
+    library: ctypes.CDLL, unique_id: ctypes.c_void_p, endpoint: int
+) -> CoreMidiEndpoint:
+    if endpoint == 0:
+        raise RuntimeError("CoreMIDI endpoint disappeared during discovery")
+    uid = ctypes.c_int32()
+    status = library.MIDIObjectGetIntegerProperty(endpoint, unique_id, ctypes.byref(uid))
+    if status != 0:
+        raise RuntimeError(f"CoreMIDI unique ID lookup failed for {endpoint}: OSStatus {status}")
+    entity = ctypes.c_uint32()
+    status = library.MIDIEndpointGetEntity(endpoint, ctypes.byref(entity))
+    # Virtual endpoints have a UID but no owning entity.
+    if status == _OBJECT_NOT_FOUND:
+        return CoreMidiEndpoint(uid.value, 0)
+    if status != 0:
+        raise RuntimeError(f"CoreMIDI entity lookup failed for {endpoint}: OSStatus {status}")
+    return CoreMidiEndpoint(uid.value, entity.value)
+
+
+def endpoint_snapshot() -> tuple[list[CoreMidiEndpoint], list[CoreMidiEndpoint]]:
+    """Read sources and destinations in RtMidi order after its client initializes."""
+    library, unique_id = _framework()
+    sources = [
+        _read_endpoint(library, unique_id, library.MIDIGetSource(index))
+        for index in range(library.MIDIGetNumberOfSources())
+    ]
+    destinations = [
+        _read_endpoint(library, unique_id, library.MIDIGetDestination(index))
+        for index in range(library.MIDIGetNumberOfDestinations())
+    ]
+    return sources, destinations
+
+
+def endpoint_ids(input_port: int, output_port: int) -> tuple[int, int]:
+    """Resolve current identities for an indexed pair before opening its ports."""
+    if input_port < 0 or output_port < 0:
+        raise ValueError("CoreMIDI port indices must be nonnegative")
+    library, unique_id = _framework()
+    source = _read_endpoint(library, unique_id, library.MIDIGetSource(input_port))
+    destination = _read_endpoint(library, unique_id, library.MIDIGetDestination(output_port))
+    return source.uid, destination.uid

--- a/src/blocksd/paths.py
+++ b/src/blocksd/paths.py
@@ -1,0 +1,28 @@
+"""Platform-specific locations for configuration and local IPC."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+
+def config_paths() -> list[Path]:
+    """Return configuration candidates in descending priority order."""
+    user_config = Path.home() / ".config" / "blocksd" / "config.toml"
+    if sys.platform == "darwin":
+        return [
+            Path.home() / "Library" / "Application Support" / "blocksd" / "config.toml",
+            user_config,
+            Path("/etc/blocksd/config.toml"),
+        ]
+    return [user_config, Path("/etc/blocksd/config.toml")]
+
+
+def default_socket_path() -> Path:
+    """Return a short socket path, independent of macOS's long TMPDIR."""
+    if sys.platform == "darwin":
+        return Path(f"/tmp/blocksd-{os.getuid()}/blocksd.sock")  # noqa: S108
+    if runtime_dir := os.environ.get("XDG_RUNTIME_DIR"):
+        return Path(runtime_dir) / "blocksd" / "blocksd.sock"
+    return Path("/tmp/blocksd/blocksd.sock")  # noqa: S108

--- a/src/blocksd/topology/detector.py
+++ b/src/blocksd/topology/detector.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 import logging
 import re
 from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from blocksd.device.coremidi import CoreMidiEndpoint
 
 log = logging.getLogger(__name__)
 
@@ -25,6 +29,15 @@ class MidiPortPair:
     input_port: int
     output_port: int
     name: str
+    endpoint_ids: tuple[int, int] | None = None
+    occurrence: int = 0
+
+    @property
+    def key(self) -> str:
+        """Identity independent of the current enumeration indices."""
+        if self.endpoint_ids is not None:
+            return f"coremidi:{self.endpoint_ids[0]}:{self.endpoint_ids[1]}"
+        return f"named:{self.name}:{self.occurrence}"
 
 
 def _is_blocks_port(name: str) -> bool:
@@ -44,10 +57,9 @@ def _clean_port_name(name: str) -> str:
 def scan_for_blocks() -> list[MidiPortPair]:
     """Scan MIDI ports and return matched input/output pairs for ROLI Blocks.
 
-    Uses the same matching strategy as roli_MIDIDeviceDetector:
-    1. Find all MIDI inputs containing "BLOCK" or "Block"
-    2. For each input, find the corresponding output by cleaned name
-    3. Handle duplicate names (multiple blocks of same type) via occurrence counting
+    Find inputs containing "BLOCK" or "Block". CoreMIDI hardware pairs by
+    owning entity and retains endpoint UIDs across index changes. Other
+    backends and virtual endpoints pair by normalized name and occurrence.
     """
     import rtmidi
 
@@ -55,14 +67,32 @@ def scan_for_blocks() -> list[MidiPortPair]:
     midi_out = rtmidi.MidiOut()
 
     try:
+        endpoints = None
+        if midi_in.get_current_api() == rtmidi.API_MACOSX_CORE:
+            from blocksd.device.coremidi import endpoint_snapshot
+
+            endpoints = endpoint_snapshot()
         input_ports = midi_in.get_ports()
         output_ports = midi_out.get_ports()
-    except Exception:
+        if endpoints is not None and endpoints != endpoint_snapshot():
+            raise RuntimeError("CoreMIDI endpoints changed during discovery")
+        return _pair_ports(input_ports, output_ports, endpoints)
+    finally:
         midi_in.delete()
         midi_out.delete()
-        raise
 
+
+def _pair_ports(
+    input_ports: list[str],
+    output_ports: list[str],
+    endpoints: tuple[list[CoreMidiEndpoint], list[CoreMidiEndpoint]] | None = None,
+) -> list[MidiPortPair]:
+    if endpoints is not None and (
+        len(endpoints[0]) != len(input_ports) or len(endpoints[1]) != len(output_ports)
+    ):
+        raise RuntimeError("CoreMIDI endpoint count changed during discovery")
     pairs: list[MidiPortPair] = []
+    used_outputs: set[int] = set()
 
     for in_idx, in_name in enumerate(input_ports):
         if not _is_blocks_port(in_name):
@@ -73,25 +103,31 @@ def scan_for_blocks() -> list[MidiPortPair]:
         # Count how many times we've already matched this cleaned name
         input_occurrences = sum(1 for p in pairs if _clean_port_name(p.name) == cleaned_in)
 
-        # Find the Nth matching output
-        output_occurrences = 0
+        # Native entities distinguish identically named physical devices.
         matched_out_idx = -1
-
         for out_idx, out_name in enumerate(output_ports):
-            if _clean_port_name(out_name) == cleaned_in:
-                if output_occurrences == input_occurrences:
-                    matched_out_idx = out_idx
-                    break
-                output_occurrences += 1
+            if out_idx in used_outputs:
+                continue
+            if endpoints is not None and endpoints[0][in_idx].entity:
+                matches = endpoints[0][in_idx].entity == endpoints[1][out_idx].entity
+            else:
+                matches = _clean_port_name(out_name) == cleaned_in and (
+                    endpoints is None or endpoints[1][out_idx].entity == 0
+                )
+            if matches:
+                matched_out_idx = out_idx
+                break
 
         if matched_out_idx >= 0:
-            pairs.append(MidiPortPair(in_idx, matched_out_idx, in_name))
+            ids = (
+                (endpoints[0][in_idx].uid, endpoints[1][matched_out_idx].uid)
+                if endpoints is not None
+                else None
+            )
+            pairs.append(MidiPortPair(in_idx, matched_out_idx, in_name, ids, input_occurrences))
+            used_outputs.add(matched_out_idx)
             log.debug("Found ROLI device: %s (in=%d, out=%d)", in_name, in_idx, matched_out_idx)
         else:
             log.warning("No matching output for ROLI input: %s", in_name)
-
-    # Close ALSA sequencer clients to avoid exhausting /dev/snd/seq slots
-    midi_in.delete()
-    midi_out.delete()
 
     return pairs

--- a/src/blocksd/topology/manager.py
+++ b/src/blocksd/topology/manager.py
@@ -34,8 +34,8 @@ class TopologyManager:
     """
 
     def __init__(self) -> None:
-        self._groups: dict[str, _GroupEntry] = {}  # port name → entry
-        self._tasks: dict[str, asyncio.Task[None]] = {}
+        self._groups: dict[MidiPortPair, _GroupEntry] = {}
+        self._tasks: dict[MidiPortPair, asyncio.Task[None]] = {}
         self._running_tasks: set[asyncio.Task[None]] = set()
         self.on_device_added: list[Callable[[DeviceInfo], None]] = []
         self.on_device_removed: list[Callable[[DeviceInfo], None]] = []
@@ -104,16 +104,20 @@ class TopologyManager:
             log.exception("MIDI scan failed")
             return
 
-        detected_names = {pair.name for pair in detected}
+        detected_pairs = set(detected)
 
         # Remove groups whose ports disappeared
-        stale = [name for name in self._groups if name not in detected_names]
-        for name in stale:
-            self._remove_group(name)
+        stale = [pair for pair in self._groups if pair not in detected_pairs]
+        retiring = [self._tasks[pair] for pair in stale if pair in self._tasks]
+        for pair in stale:
+            self._remove_group(pair)
+        # Reindexed ports may still own native handles until cancellation completes.
+        # Release them before opening replacements that refer to the same device.
+        await asyncio.gather(*retiring, return_exceptions=True)
 
         # Add groups for newly detected ports
         for pair in detected:
-            if pair.name not in self._groups:
+            if pair not in self._groups:
                 self._add_group(pair)
 
     def _add_group(self, pair: MidiPortPair) -> None:
@@ -135,32 +139,32 @@ class TopologyManager:
 
         task = asyncio.create_task(group.run(), name=f"group:{pair.name}")
         self._running_tasks.add(task)
-        task.add_done_callback(lambda t, n=pair.name: self._on_group_done(n, t))
+        task.add_done_callback(lambda t, p=pair: self._on_group_done(p, t))
 
-        self._groups[pair.name] = _GroupEntry(group, pair)
-        self._tasks[pair.name] = task
+        self._groups[pair] = _GroupEntry(group, pair)
+        self._tasks[pair] = task
         log.info("Created device group for %s", pair.name)
 
-    def _remove_group(self, name: str) -> None:
+    def _remove_group(self, pair: MidiPortPair) -> None:
         """Cancel and clean up a device group."""
-        if task := self._tasks.pop(name, None):
+        if task := self._tasks.pop(pair, None):
             task.cancel()
-        self._groups.pop(name, None)
-        log.info("Removed device group for %s", name)
+        self._groups.pop(pair, None)
+        log.info("Removed device group for %s", pair.name)
 
-    def _on_group_done(self, name: str, task: asyncio.Task[None]) -> None:
+    def _on_group_done(self, pair: MidiPortPair, task: asyncio.Task[None]) -> None:
         """Handle a group task completing (disconnection or failure)."""
         self._running_tasks.discard(task)
         # A disconnected port may already have a replacement group by this point.
-        if self._tasks.get(name) is task:
-            self._groups.pop(name, None)
-            self._tasks.pop(name, None)
+        if self._tasks.get(pair) is task:
+            self._groups.pop(pair, None)
+            self._tasks.pop(pair, None)
         if task.cancelled():
             return
         if error := task.exception():
-            log.error("Device group %s failed: %s", name, error)
+            log.error("Device group %s failed: %s", pair.name, error)
         else:
-            log.info("Device group %s finished", name)
+            log.info("Device group %s finished", pair.name)
 
     async def _shutdown(self) -> None:
         """Join active and retiring groups before relinquishing MIDI ownership."""

--- a/src/blocksd/topology/manager.py
+++ b/src/blocksd/topology/manager.py
@@ -34,8 +34,8 @@ class TopologyManager:
     """
 
     def __init__(self) -> None:
-        self._groups: dict[MidiPortPair, _GroupEntry] = {}
-        self._tasks: dict[MidiPortPair, asyncio.Task[None]] = {}
+        self._groups: dict[str, _GroupEntry] = {}
+        self._tasks: dict[str, asyncio.Task[None]] = {}
         self._running_tasks: set[asyncio.Task[None]] = set()
         self.on_device_added: list[Callable[[DeviceInfo], None]] = []
         self.on_device_removed: list[Callable[[DeviceInfo], None]] = []
@@ -104,27 +104,32 @@ class TopologyManager:
             log.exception("MIDI scan failed")
             return
 
-        detected_pairs = set(detected)
+        detected_keys = {pair.key for pair in detected}
 
         # Remove groups whose ports disappeared
-        stale = [pair for pair in self._groups if pair not in detected_pairs]
-        retiring = [self._tasks[pair] for pair in stale if pair in self._tasks]
-        for pair in stale:
-            self._remove_group(pair)
-        # Reindexed ports may still own native handles until cancellation completes.
-        # Release them before opening replacements that refer to the same device.
+        stale = [key for key in self._groups if key not in detected_keys]
+        retiring = [self._tasks[key] for key in stale if key in self._tasks]
+        for key in stale:
+            self._remove_group(key)
+        # Release disappeared endpoints before opening newly discovered devices.
         await asyncio.gather(*retiring, return_exceptions=True)
 
         # Add groups for newly detected ports
         for pair in detected:
-            if pair not in self._groups:
+            if pair.key not in self._groups:
                 self._add_group(pair)
 
     def _add_group(self, pair: MidiPortPair) -> None:
         """Create a DeviceGroup for a newly detected MIDI port pair."""
         loop = asyncio.get_event_loop()
         try:
-            conn = open_connection(pair.input_port, pair.output_port, loop, name=pair.name)
+            conn = open_connection(
+                pair.input_port,
+                pair.output_port,
+                loop,
+                name=pair.name,
+                endpoint_ids=pair.endpoint_ids,
+            )
         except Exception:
             log.exception("Failed to open MIDI ports for %s", pair.name)
             return
@@ -139,32 +144,32 @@ class TopologyManager:
 
         task = asyncio.create_task(group.run(), name=f"group:{pair.name}")
         self._running_tasks.add(task)
-        task.add_done_callback(lambda t, p=pair: self._on_group_done(p, t))
+        task.add_done_callback(lambda t, key=pair.key: self._on_group_done(key, t))
 
-        self._groups[pair] = _GroupEntry(group, pair)
-        self._tasks[pair] = task
+        self._groups[pair.key] = _GroupEntry(group, pair)
+        self._tasks[pair.key] = task
         log.info("Created device group for %s", pair.name)
 
-    def _remove_group(self, pair: MidiPortPair) -> None:
+    def _remove_group(self, key: str) -> None:
         """Cancel and clean up a device group."""
-        if task := self._tasks.pop(pair, None):
+        if task := self._tasks.pop(key, None):
             task.cancel()
-        self._groups.pop(pair, None)
-        log.info("Removed device group for %s", pair.name)
+        entry = self._groups.pop(key, None)
+        log.info("Removed device group for %s", entry.pair.name if entry else key)
 
-    def _on_group_done(self, pair: MidiPortPair, task: asyncio.Task[None]) -> None:
+    def _on_group_done(self, key: str, task: asyncio.Task[None]) -> None:
         """Handle a group task completing (disconnection or failure)."""
         self._running_tasks.discard(task)
         # A disconnected port may already have a replacement group by this point.
-        if self._tasks.get(pair) is task:
-            self._groups.pop(pair, None)
-            self._tasks.pop(pair, None)
+        if self._tasks.get(key) is task:
+            self._groups.pop(key, None)
+            self._tasks.pop(key, None)
         if task.cancelled():
             return
         if error := task.exception():
-            log.error("Device group %s failed: %s", pair.name, error)
+            log.error("Device group %s failed: %s", key, error)
         else:
-            log.info("Device group %s finished", pair.name)
+            log.info("Device group %s finished", key)
 
     async def _shutdown(self) -> None:
         """Join active and retiring groups before relinquishing MIDI ownership."""

--- a/tests/cli/test_install.py
+++ b/tests/cli/test_install.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import os
+import shutil
 import subprocess
 from pathlib import Path
 from unittest.mock import Mock
@@ -12,6 +12,11 @@ from typer.testing import CliRunner
 
 from blocksd.cli import install
 from blocksd.cli.app import app
+
+
+@pytest.fixture(autouse=True)
+def linux_platform(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(install.sys, "platform", "linux")
 
 
 @pytest.fixture
@@ -64,6 +69,7 @@ def test_service_errors_fail_install(setup_commands: Mock, failed_step: str) -> 
     result = CliRunner().invoke(app, ["install", "--no-udev"])
     assert result.exit_code == 1
     assert "Command failed" in result.output
+    assert "Installation failed" not in result.output
     assert "Installation complete" not in result.output
 
 
@@ -145,7 +151,6 @@ def shell_env(tmp_path: Path) -> dict[str, str]:
     )
     binary.chmod(0o755)
     return {
-        **os.environ,
         "PATH": f"{bin_dir}:/usr/bin:/bin",
         "HOME": str(tmp_path),
         "INSTALL_LOG": str(tmp_path / "commands"),
@@ -201,7 +206,9 @@ def bootstrap_env(shell_env: dict[str, str]) -> dict[str, str]:
     uv_source = (bin_dir / "uv").read_text()
     (bin_dir / "uv").unlink()
     for command in ("sh", "mktemp", "rm", "mkdir", "cp", "chmod"):
-        (bin_dir / command).symlink_to(Path("/usr/bin") / command)
+        executable = shutil.which(command)
+        assert executable is not None
+        (bin_dir / command).symlink_to(executable)
     source = bin_dir / "uv-source"
     source.write_text(uv_source)
     source.chmod(0o755)
@@ -227,6 +234,21 @@ def test_bootstrap_without_uv_is_noninteractive(bootstrap_env: dict[str, str]) -
         "blocksd:install --no-udev --no-service" in Path(bootstrap_env["INSTALL_LOG"]).read_text()
     )
     assert not list(Path(bootstrap_env["TMPDIR"]).iterdir())
+
+
+def test_bootstrap_supports_macos(bootstrap_env: dict[str, str]) -> None:
+    (Path(bootstrap_env["HOME"]) / "bin" / "uname").write_text("#!/bin/sh\nprintf 'Darwin\\n'\n")
+    result = run_installer(bootstrap_env, "--no-enable")
+    assert result.returncode == 0, result.stderr
+    assert "blocksd:install --no-enable" in Path(bootstrap_env["INSTALL_LOG"]).read_text()
+
+
+def test_shell_rejects_unsupported_platform(shell_env: dict[str, str]) -> None:
+    (Path(shell_env["HOME"]) / "bin" / "uname").write_text("#!/bin/sh\nprintf 'FreeBSD\\n'\n")
+    result = run_installer(shell_env)
+    assert result.returncode == 1
+    assert "Linux and macOS only" in result.stderr
+    assert not Path(shell_env["INSTALL_LOG"]).exists()
 
 
 @pytest.mark.parametrize("failed_command", ["curl", "bootstrap"])

--- a/tests/cli/test_launchd.py
+++ b/tests/cli/test_launchd.py
@@ -1,0 +1,183 @@
+"""LaunchAgent lifecycle checks with all launchctl calls intercepted."""
+
+from __future__ import annotations
+
+import plistlib
+import subprocess
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+from typer.testing import CliRunner
+
+from blocksd.cli import install, launchd
+from blocksd.cli.app import app
+
+
+@pytest.fixture
+def agent_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Mock:
+    monkeypatch.setattr(install.sys, "platform", "darwin")
+    monkeypatch.setattr(launchd.Path, "home", lambda: tmp_path)
+    monkeypatch.setattr(launchd.os, "getuid", lambda: 501)
+    monkeypatch.setattr(install, "_find_blocksd_bin", lambda: '/opt/a & "b"/blocksd')
+    monkeypatch.setattr(install, "_install_udev", Mock(side_effect=AssertionError))
+    commands = Mock(return_value=subprocess.CompletedProcess([], 0, "", ""))
+    monkeypatch.setattr(launchd.subprocess, "run", commands)
+    return commands
+
+
+def test_generated_plist_preserves_executable_and_log_paths(agent_env: Mock) -> None:
+    result = CliRunner().invoke(app, ["install", "--no-enable"])
+    assert result.exit_code == 0, result.output
+    agent_env.assert_not_called()
+    path = launchd._plist_path()
+    data = plistlib.loads(path.read_bytes())
+    assert data["Label"] == launchd.LABEL
+    assert data["ProgramArguments"] == ['/opt/a & "b"/blocksd', "run", "--daemon"]
+    assert data["RunAtLoad"] is True
+    assert data["KeepAlive"] == {"SuccessfulExit": False}
+    assert Path(data["StandardOutPath"]).parent.is_dir()
+    assert data["StandardErrorPath"].endswith("/Library/Logs/blocksd/stderr.log")
+    assert path.stat().st_mode & 0o777 == 0o644
+
+
+def test_install_and_reinstall_load_current_definition(agent_env: Mock) -> None:
+    target = f"gui/501/{launchd.LABEL}"
+    agent_env.side_effect = [
+        subprocess.CompletedProcess([], 113, "", "service missing"),
+        *[subprocess.CompletedProcess([], 0, "", "")] * 5,
+        subprocess.CompletedProcess([], 113, "", "service missing"),
+        *[subprocess.CompletedProcess([], 0, "", "")] * 3,
+    ]
+    for _ in range(2):
+        result = CliRunner().invoke(app, ["install"])
+        assert result.exit_code == 0, result.output
+    assert [call.args[0] for call in agent_env.call_args_list] == [
+        ["launchctl", "print", target],
+        ["launchctl", "enable", target],
+        ["launchctl", "bootstrap", "gui/501", str(launchd._plist_path())],
+        ["launchctl", "kickstart", target],
+        ["launchctl", "print", target],
+        ["launchctl", "bootout", target],
+        ["launchctl", "print", target],
+        ["launchctl", "enable", target],
+        ["launchctl", "bootstrap", "gui/501", str(launchd._plist_path())],
+        ["launchctl", "kickstart", target],
+    ]
+
+
+@pytest.mark.parametrize("failed_step", ["print", "bootout", "enable", "bootstrap", "kickstart"])
+def test_install_reports_launchctl_errors(agent_env: Mock, failed_step: str) -> None:
+    loaded = True
+
+    def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+        nonlocal loaded
+        code = 5 if command[1] == failed_step else 0
+        if code == 0 and command[1] == "print" and not loaded:
+            code = 113
+        if command[1] == "bootout":
+            loaded = False
+        return subprocess.CompletedProcess(command, code, "", "operation denied")
+
+    agent_env.side_effect = run
+    result = CliRunner().invoke(app, ["install"])
+    assert result.exit_code == 1
+    assert failed_step in result.output
+    assert "operation denied" in result.output
+    assert "Installation complete" not in result.output
+    assert agent_env.call_args.args[0][1] == failed_step
+
+
+def test_no_service_does_not_touch_host(agent_env: Mock, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(install, "_find_blocksd_bin", Mock(side_effect=AssertionError))
+    result = CliRunner().invoke(app, ["install", "--no-service"])
+    assert result.exit_code == 0, result.output
+    agent_env.assert_not_called()
+    assert not launchd._plist_path().exists()
+
+
+def test_repeated_uninstall_preserves_logs(agent_env: Mock) -> None:
+    assert CliRunner().invoke(app, ["install", "--no-enable"]).exit_code == 0
+    agent_env.side_effect = [
+        subprocess.CompletedProcess([], 0, "", ""),
+        subprocess.CompletedProcess([], 0, "", ""),
+        subprocess.CompletedProcess([], 113, "", "service missing"),
+        subprocess.CompletedProcess([], 113, "", "service missing"),
+    ]
+    for _ in range(2):
+        result = CliRunner().invoke(app, ["uninstall"])
+        assert result.exit_code == 0, result.output
+    assert not launchd._plist_path().exists()
+    assert (Path.home() / "Library" / "Logs" / "blocksd").is_dir()
+    assert [call.args[0][1] for call in agent_env.call_args_list] == [
+        "print",
+        "bootout",
+        "print",
+        "print",
+    ]
+
+
+def test_reinstall_waits_until_launchd_reaps_previous_service(
+    agent_env: Mock, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    pause = Mock()
+    monkeypatch.setattr(launchd.time, "sleep", pause)
+    agent_env.side_effect = [
+        *[subprocess.CompletedProcess([], 0, "", "")] * 4,
+        subprocess.CompletedProcess([], 113, "", "service missing"),
+        *[subprocess.CompletedProcess([], 0, "", "")] * 3,
+    ]
+    result = CliRunner().invoke(app, ["install"])
+    assert result.exit_code == 0, result.output
+    assert [call.args[0][1] for call in agent_env.call_args_list] == [
+        "print",
+        "bootout",
+        "print",
+        "print",
+        "print",
+        "enable",
+        "bootstrap",
+        "kickstart",
+    ]
+    assert pause.call_count == 2
+
+
+@pytest.mark.parametrize("command", ["install", "uninstall"])
+def test_unload_timeout_stops_mutations_and_keeps_plist(
+    agent_env: Mock, monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    assert CliRunner().invoke(app, ["install", "--no-enable"]).exit_code == 0
+    monkeypatch.setattr(launchd.time, "monotonic", Mock(side_effect=[0, 36]))
+    result = CliRunner().invoke(app, [command])
+    assert result.exit_code == 1
+    assert "Timed out waiting for launchd to unload" in result.output
+    assert launchd._plist_path().exists()
+    assert [call.args[0][1] for call in agent_env.call_args_list] == ["print", "bootout", "print"]
+
+
+def test_uninstall_keeps_plist_when_unload_fails(agent_env: Mock) -> None:
+    assert CliRunner().invoke(app, ["install", "--no-enable"]).exit_code == 0
+    agent_env.side_effect = [
+        subprocess.CompletedProcess([], 0, "", ""),
+        subprocess.CompletedProcess([], 5, "", "permission denied"),
+    ]
+    result = CliRunner().invoke(app, ["uninstall"])
+    assert result.exit_code == 1
+    assert "permission denied" in result.output
+    assert launchd._plist_path().exists()
+
+
+@pytest.mark.parametrize("command", ["install", "uninstall"])
+def test_unsupported_platform_fails_before_mutation(
+    agent_env: Mock, monkeypatch: pytest.MonkeyPatch, command: str
+) -> None:
+    monkeypatch.setattr(install.sys, "platform", "win32")
+    result = CliRunner().invoke(app, [command])
+    assert result.exit_code == 1
+    assert "Linux and macOS only" in result.output
+    agent_env.assert_not_called()
+
+
+def test_launchagent_requires_absolute_executable() -> None:
+    with pytest.raises(ValueError, match="must be absolute"):
+        launchd._generate_plist("blocksd")

--- a/tests/device/test_connection.py
+++ b/tests/device/test_connection.py
@@ -1,0 +1,33 @@
+"""Avoid opening a different device when CoreMIDI indices change."""
+
+import asyncio
+from unittest.mock import Mock
+
+import pytest
+
+from blocksd.device.connection import open_connection
+
+
+@pytest.mark.parametrize("phase", ["before", "after", "output_failure"])
+async def test_failed_open_releases_both_native_clients(monkeypatch, phase):
+    import rtmidi
+
+    from blocksd.device import coremidi
+
+    midi_in = Mock()
+    midi_out = Mock()
+    monkeypatch.setattr(rtmidi, "MidiIn", lambda: midi_in)
+    monkeypatch.setattr(rtmidi, "MidiOut", lambda: midi_out)
+    snapshots = [(3, 4)] if phase == "before" else [(1, 2), (3, 4)]
+    monkeypatch.setattr(coremidi, "endpoint_ids", Mock(side_effect=snapshots))
+    if phase == "output_failure":
+        midi_out.open_port.side_effect = RuntimeError("port disappeared")
+    with pytest.raises(RuntimeError):
+        open_connection(0, 0, asyncio.get_running_loop(), endpoint_ids=(1, 2))
+    midi_in.close_port.assert_called_once()
+    midi_in.delete.assert_called_once()
+    midi_out.close_port.assert_called_once()
+    midi_out.delete.assert_called_once()
+    if phase == "before":
+        midi_in.open_port.assert_not_called()
+    midi_out.send_message.assert_not_called()

--- a/tests/device/test_coremidi.py
+++ b/tests/device/test_coremidi.py
@@ -1,0 +1,101 @@
+"""Native discovery behavior with CoreMIDI calls replaced by typed callbacks."""
+
+from __future__ import annotations
+
+import ctypes
+from unittest.mock import Mock
+
+import pytest
+
+from blocksd.device import coremidi
+
+
+@pytest.fixture
+def framework(monkeypatch: pytest.MonkeyPatch) -> Mock:
+    library = Mock()
+    sources = [101, 202]
+    destinations = [303, 404]
+    library.MIDIGetNumberOfSources.return_value = len(sources)
+    library.MIDIGetNumberOfDestinations.return_value = len(destinations)
+    library.MIDIGetSource.side_effect = sources.__getitem__
+    library.MIDIGetDestination.side_effect = destinations.__getitem__
+
+    @ctypes.CFUNCTYPE(
+        ctypes.c_int32, ctypes.c_uint32, ctypes.c_void_p, ctypes.POINTER(ctypes.c_int32)
+    )
+    def get_uid(endpoint, property_id, output):
+        output[0] = -endpoint
+        return 0
+
+    @ctypes.CFUNCTYPE(ctypes.c_int32, ctypes.c_uint32, ctypes.POINTER(ctypes.c_uint32))
+    def get_entity(endpoint, output):
+        output[0] = 10 if endpoint in {101, 303} else 0
+        return 0
+
+    library.MIDIObjectGetIntegerProperty.side_effect = get_uid
+    library.MIDIEndpointGetEntity.side_effect = get_entity
+    monkeypatch.setattr(coremidi, "_framework", lambda: (library, ctypes.c_void_p(1)))
+    return library
+
+
+def test_snapshot_keeps_order_signed_ids_and_virtual_entities(framework: Mock) -> None:
+    sources, destinations = coremidi.endpoint_snapshot()
+    assert sources == [coremidi.CoreMidiEndpoint(-101, 10), coremidi.CoreMidiEndpoint(-202, 0)]
+    assert destinations == [coremidi.CoreMidiEndpoint(-303, 10), coremidi.CoreMidiEndpoint(-404, 0)]
+
+
+def test_endpoint_ids_query_current_indices(framework: Mock) -> None:
+    assert coremidi.endpoint_ids(1, 0) == (-202, -303)
+    framework.MIDIGetSource.assert_called_once_with(1)
+    framework.MIDIGetDestination.assert_called_once_with(0)
+    framework.MIDIGetNumberOfSources.assert_not_called()
+
+
+def test_virtual_endpoint_without_an_owner_is_valid(framework: Mock) -> None:
+    framework.MIDIEndpointGetEntity.side_effect = None
+    framework.MIDIEndpointGetEntity.return_value = -10842
+    sources, destinations = coremidi.endpoint_snapshot()
+    assert [endpoint.entity for endpoint in sources + destinations] == [0, 0, 0, 0]
+    assert coremidi.endpoint_ids(0, 0) == (-101, -303)
+
+
+@pytest.mark.parametrize("indices", [(-1, 0), (0, -1)])
+def test_negative_indices_are_rejected(framework: Mock, indices: tuple[int, int]) -> None:
+    with pytest.raises(ValueError, match="nonnegative"):
+        coremidi.endpoint_ids(*indices)
+    framework.MIDIGetSource.assert_not_called()
+
+
+def test_missing_endpoint_is_not_silently_accepted(framework: Mock) -> None:
+    framework.MIDIGetSource.side_effect = None
+    framework.MIDIGetSource.return_value = 0
+    with pytest.raises(RuntimeError, match="disappeared"):
+        coremidi.endpoint_snapshot()
+
+
+@pytest.mark.parametrize(
+    ("function", "message"),
+    [("MIDIObjectGetIntegerProperty", "unique ID"), ("MIDIEndpointGetEntity", "entity")],
+)
+def test_native_status_errors_preserve_code(framework: Mock, function: str, message: str) -> None:
+    native = getattr(framework, function)
+    native.side_effect = None
+    native.return_value = -10830
+    with pytest.raises(RuntimeError, match=f"{message}.*OSStatus -10830"):
+        coremidi.endpoint_ids(0, 0)
+
+
+def test_empty_system_returns_empty_snapshot(framework: Mock) -> None:
+    framework.MIDIGetNumberOfSources.return_value = 0
+    framework.MIDIGetNumberOfDestinations.return_value = 0
+    assert coremidi.endpoint_snapshot() == ([], [])
+
+
+def test_framework_loading_is_guarded_and_lazy(monkeypatch: pytest.MonkeyPatch) -> None:
+    coremidi._framework.cache_clear()
+    monkeypatch.setattr(coremidi.sys, "platform", "linux")
+    loader = Mock(side_effect=AssertionError("must not load framework"))
+    monkeypatch.setattr(coremidi.ctypes, "CDLL", loader)
+    with pytest.raises(RuntimeError, match="requires macOS"):
+        coremidi.endpoint_snapshot()
+    loader.assert_not_called()

--- a/tests/test_api_lifecycle.py
+++ b/tests/test_api_lifecycle.py
@@ -3,6 +3,8 @@
 import asyncio
 import base64
 import json
+import tempfile
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
@@ -11,13 +13,20 @@ from blocksd.api.server import ApiServer, WebServer
 from blocksd.topology.manager import TopologyManager
 
 
+@pytest.fixture
+def socket_dir():
+    """Unix socket addresses must fit even when macOS TMPDIR is long."""
+    with tempfile.TemporaryDirectory(prefix="blocksd-", dir="/tmp") as directory:
+        yield Path(directory)
+
+
 @pytest.mark.parametrize("transport", ["unix", "tcp"])
-async def test_stop_closes_idle_clients_and_detaches_events(tmp_path, transport):
+async def test_stop_closes_idle_clients_and_detaches_events(socket_dir, transport):
     manager = TopologyManager()
     if transport == "unix":
-        server = ApiServer(manager, tmp_path / "api.sock")
+        server = ApiServer(manager, socket_dir / "api.sock")
         await server.start()
-        reader, writer = await asyncio.open_unix_connection(str(tmp_path / "api.sock"))
+        reader, writer = await asyncio.open_unix_connection(str(socket_dir / "api.sock"))
     else:
         server = WebServer(manager, port=0)
         await server.start()
@@ -52,8 +61,8 @@ async def test_socket_path_does_not_replace_regular_file(tmp_path):
     assert path.read_text() == "keep me"
 
 
-async def test_second_server_cannot_unlink_active_socket(tmp_path):
-    path = tmp_path / "api.sock"
+async def test_second_server_cannot_unlink_active_socket(socket_dir):
+    path = socket_dir / "api.sock"
     first = ApiServer(TopologyManager(), path)
     second = ApiServer(TopologyManager(), path)
     await first.start()
@@ -185,7 +194,7 @@ async def test_invalid_config_retains_request_id(server_class, value):
 
 @pytest.mark.parametrize("transport", ["unix", "websocket"])
 async def test_transport_keeps_connection_after_compatibility_requests(
-    tmp_path, monkeypatch, transport
+    socket_dir, monkeypatch, transport
 ):
     from blocksd.api.websocket import read_frame
     from tests.test_web_server import _build_masked_frame
@@ -194,9 +203,9 @@ async def test_transport_keeps_connection_after_compatibility_requests(
     set_config = Mock(return_value=True)
     monkeypatch.setattr(manager, "set_config", set_config)
     if transport == "unix":
-        server = ApiServer(manager, tmp_path / "compat.sock")
+        server = ApiServer(manager, socket_dir / "compat.sock")
         await server.start()
-        reader, writer = await asyncio.open_unix_connection(str(tmp_path / "compat.sock"))
+        reader, writer = await asyncio.open_unix_connection(str(socket_dir / "compat.sock"))
     else:
         server = WebServer(manager, port=0)
         await server.start()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,88 @@
+"""Platform defaults and isolation of the macOS local socket."""
+
+# Expected socket addresses, never used as test write targets.
+# ruff: noqa: S108
+
+import os
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from blocksd import paths
+from blocksd.api import server
+from blocksd.config.loader import load_config
+from blocksd.topology.manager import TopologyManager
+
+
+def test_macos_config_prefers_native_then_legacy(monkeypatch, tmp_path):
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+    monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
+    native, legacy, system = paths.config_paths()
+    assert native == tmp_path / "Library/Application Support/blocksd/config.toml"
+    assert legacy == tmp_path / ".config/blocksd/config.toml"
+    assert system == Path("/etc/blocksd/config.toml")
+    legacy.parent.mkdir(parents=True)
+    legacy.write_text("[daemon]\nweb_port = 9011\n")
+    assert load_config().web_port == 9011
+    native.parent.mkdir(parents=True)
+    native.write_text("[daemon]\nweb_port = 9012\n")
+    assert load_config().web_port == 9012
+    assert load_config(legacy).web_port == 9011
+
+
+def test_linux_paths_are_unchanged(monkeypatch, tmp_path):
+    monkeypatch.setattr(paths.sys, "platform", "linux")
+    monkeypatch.setattr(paths.Path, "home", lambda: tmp_path)
+    assert paths.config_paths() == [
+        tmp_path / ".config/blocksd/config.toml",
+        Path("/etc/blocksd/config.toml"),
+    ]
+    monkeypatch.setenv("XDG_RUNTIME_DIR", str(tmp_path))
+    assert paths.default_socket_path() == tmp_path / "blocksd/blocksd.sock"
+    monkeypatch.delenv("XDG_RUNTIME_DIR")
+    assert paths.default_socket_path() == Path("/tmp/blocksd/blocksd.sock")
+
+
+def test_macos_socket_is_short_and_user_specific(monkeypatch):
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+    monkeypatch.setattr(paths.os, "getuid", lambda: 501)
+    monkeypatch.setenv("TMPDIR", "/very/long/" * 30)
+    monkeypatch.setenv("XDG_RUNTIME_DIR", "/other/runtime")
+    assert paths.default_socket_path() == Path("/tmp/blocksd-501/blocksd.sock")
+    monkeypatch.setattr(paths.os, "getuid", lambda: 502)
+    assert paths.default_socket_path() == Path("/tmp/blocksd-502/blocksd.sock")
+
+
+@pytest.mark.parametrize("unsafe", ["symlink", "shared", "foreign"])
+async def test_macos_rejects_unsafe_default_socket_directory(monkeypatch, tmp_path, unsafe):
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+    directory = tmp_path / "runtime"
+    directory.mkdir(mode=0o700)
+    if unsafe == "symlink":
+        link = tmp_path / "link"
+        link.symlink_to(directory, target_is_directory=True)
+        directory = link
+    elif unsafe == "shared":
+        directory.chmod(0o755)
+    else:
+        monkeypatch.setattr(paths.os, "getuid", lambda: directory.stat().st_uid + 1)
+    monkeypatch.setattr(server, "default_socket_path", lambda: directory / "api.sock")
+    api = server.ApiServer(TopologyManager())
+    with pytest.raises(PermissionError, match="private and owned"):
+        await api.start()
+    assert not (directory / "api.sock").exists()
+
+
+async def test_macos_private_runtime_is_created(monkeypatch, tmp_path):
+    monkeypatch.setattr(paths.sys, "platform", "darwin")
+    directory = tmp_path / "runtime"
+    monkeypatch.setattr(server, "default_socket_path", lambda: directory / "api.sock")
+    # Stop before binding: the long pytest temp path is not a valid socket address.
+    bind = Mock(side_effect=RuntimeError("reached bind"))
+    monkeypatch.setattr(server.asyncio, "start_unix_server", bind)
+    api = server.ApiServer(TopologyManager())
+    with pytest.raises(RuntimeError, match="reached bind"):
+        await api.start()
+    assert directory.stat().st_mode & 0o777 == 0o700
+    assert directory.stat().st_uid == os.getuid()

--- a/tests/topology/test_detector.py
+++ b/tests/topology/test_detector.py
@@ -1,6 +1,15 @@
 """Tests for MIDI port name matching — no hardware required."""
 
-from blocksd.topology.detector import _clean_port_name, _is_blocks_port
+from unittest.mock import Mock
+
+import pytest
+
+from blocksd.topology.detector import (
+    _clean_port_name,
+    _is_blocks_port,
+    _pair_ports,
+    scan_for_blocks,
+)
 
 
 class TestBlocksPortDetection:
@@ -45,3 +54,70 @@ class TestPortNameCleaning:
         cleaned_in = _clean_port_name("Lightpad BLOCK IN)")
         cleaned_out = _clean_port_name("Lightpad BLOCK OUT)")
         assert cleaned_in == cleaned_out
+
+
+def test_native_entities_pair_duplicates_in_different_enumeration_orders():
+    from blocksd.device.coremidi import CoreMidiEndpoint
+
+    pairs = _pair_ports(
+        ["Lightpad BLOCK", "Lightpad BLOCK"],
+        ["Lightpad BLOCK", "Lightpad BLOCK"],
+        (
+            [CoreMidiEndpoint(10, 100), CoreMidiEndpoint(11, 101)],
+            [CoreMidiEndpoint(21, 101), CoreMidiEndpoint(20, 100)],
+        ),
+    )
+    assert [(pair.input_port, pair.output_port) for pair in pairs] == [(0, 1), (1, 0)]
+    assert [pair.endpoint_ids for pair in pairs] == [(10, 20), (11, 21)]
+    assert pairs[0].key != pairs[1].key
+
+
+def test_named_pairs_preserve_identity_when_unrelated_port_is_removed():
+    first = _pair_ports(["Keyboard", "Lightpad BLOCK"], ["Keyboard", "Lightpad BLOCK"])
+    second = _pair_ports(["Lightpad BLOCK"], ["Lightpad BLOCK"])
+    assert first[0].key == second[0].key
+    assert first[0].input_port != second[0].input_port
+
+
+def test_virtual_name_cannot_consume_a_physical_destination():
+    from blocksd.device.coremidi import CoreMidiEndpoint
+
+    pairs = _pair_ports(
+        ["Lightpad BLOCK", "Lightpad BLOCK"],
+        ["Lightpad BLOCK", "Lightpad BLOCK"],
+        (
+            [CoreMidiEndpoint(1, 0), CoreMidiEndpoint(2, 10)],
+            [CoreMidiEndpoint(3, 10), CoreMidiEndpoint(4, 0)],
+        ),
+    )
+    assert [pair.endpoint_ids for pair in pairs] == [(1, 4), (2, 3)]
+
+
+def test_native_count_mismatch_is_rejected():
+    with pytest.raises(RuntimeError, match="count changed"):
+        _pair_ports(["Lightpad BLOCK"], [], ([], []))
+
+
+def test_scan_rejects_hotplug_during_enumeration_and_releases_clients(monkeypatch):
+    import rtmidi
+
+    from blocksd.device import coremidi
+
+    midi_in = Mock()
+    midi_out = Mock()
+    core_api = object()
+    monkeypatch.setattr(rtmidi, "API_MACOSX_CORE", core_api)
+    midi_in.get_current_api.return_value = core_api
+    midi_in.get_ports.return_value = ["Lightpad BLOCK"]
+    midi_out.get_ports.return_value = ["Lightpad BLOCK"]
+    monkeypatch.setattr(rtmidi, "MidiIn", lambda: midi_in)
+    monkeypatch.setattr(rtmidi, "MidiOut", lambda: midi_out)
+    monkeypatch.setattr(
+        coremidi,
+        "endpoint_snapshot",
+        Mock(side_effect=[([coremidi.CoreMidiEndpoint(1, 1)], []), ([], [])]),
+    )
+    with pytest.raises(RuntimeError, match="changed during discovery"):
+        scan_for_blocks()
+    midi_in.delete.assert_called_once()
+    midi_out.delete.assert_called_once()

--- a/tests/topology/test_manager.py
+++ b/tests/topology/test_manager.py
@@ -3,10 +3,12 @@
 import asyncio
 from unittest.mock import Mock
 
+import pytest
+
 from blocksd.topology.detector import MidiPortPair
 from blocksd.topology.manager import TopologyManager
 
-PORT = MidiPortPair(0, 0, "port")
+PORT = MidiPortPair(0, 0, "port").key
 
 
 async def test_old_completion_preserves_replacement_group():
@@ -81,10 +83,14 @@ async def test_shutdown_does_not_cancel_in_progress_group_cleanup():
     assert cleaned.is_set()
 
 
-async def test_duplicate_names_keep_independent_groups(monkeypatch):
+@pytest.mark.parametrize("removed_index", [0, 1])
+async def test_duplicate_names_keep_independent_groups(monkeypatch, removed_index):
     from blocksd.topology import manager as module
 
-    pairs = [MidiPortPair(0, 0, "Lightpad BLOCK"), MidiPortPair(1, 1, "Lightpad BLOCK")]
+    pairs = [
+        MidiPortPair(0, 0, "Lightpad BLOCK", (10, 20)),
+        MidiPortPair(1, 1, "Lightpad BLOCK", (11, 21)),
+    ]
     monkeypatch.setattr(module, "scan_for_blocks", lambda: list(pairs))
 
     async def run_group(_self):
@@ -100,19 +106,24 @@ async def test_duplicate_names_keep_independent_groups(monkeypatch):
         assert open_port.call_count == 2
         await manager._scan_cycle()
         assert open_port.call_count == 2
-        pairs.pop()
+        pairs.pop(removed_index)
+        survivor = pairs[0]
+        original_group = manager._groups[survivor.key]
+        pairs[:] = [MidiPortPair(0, 0, survivor.name, survivor.endpoint_ids)]
         await manager._scan_cycle()
         assert len(manager.groups) == 1
-        assert pairs[0] in manager._groups
+        assert manager._groups[survivor.key] is original_group
+        assert open_port.call_count == 2
     finally:
         await manager._shutdown()
 
 
-async def test_reindexed_port_releases_old_handle_before_reopening(monkeypatch):
+@pytest.mark.parametrize("ids", [None, (10, 20)])
+async def test_reindexed_port_preserves_live_handle(monkeypatch, ids):
     from blocksd.topology import manager as module
 
-    old_pair = MidiPortPair(1, 1, "Lightpad BLOCK")
-    new_pair = MidiPortPair(0, 0, "Lightpad BLOCK")
+    old_pair = MidiPortPair(1, 1, "Lightpad BLOCK", ids)
+    new_pair = MidiPortPair(0, 0, "Lightpad BLOCK", ids)
     pairs = [old_pair]
     closed = asyncio.Event()
     started = asyncio.Event()
@@ -125,11 +136,7 @@ async def test_reindexed_port_releases_old_handle_before_reopening(monkeypatch):
             await asyncio.sleep(0)
             closed.set()
 
-    def open_port(*_args, **_kwargs):
-        if pairs == [new_pair]:
-            assert closed.is_set()
-        return Mock()
-
+    open_port = Mock(return_value=Mock())
     monkeypatch.setattr(module, "scan_for_blocks", lambda: list(pairs))
     monkeypatch.setattr(module, "open_connection", open_port)
     monkeypatch.setattr(module.DeviceGroup, "run", run_group)
@@ -137,8 +144,11 @@ async def test_reindexed_port_releases_old_handle_before_reopening(monkeypatch):
     try:
         await manager._scan_cycle()
         await started.wait()
+        original_group = manager._groups[old_pair.key]
         pairs[:] = [new_pair]
         await manager._scan_cycle()
-        assert set(manager._groups) == {new_pair}
+        assert manager._groups[new_pair.key] is original_group
+        assert not closed.is_set()
+        assert open_port.call_count == 1
     finally:
         await manager._shutdown()

--- a/tests/topology/test_manager.py
+++ b/tests/topology/test_manager.py
@@ -3,7 +3,10 @@
 import asyncio
 from unittest.mock import Mock
 
+from blocksd.topology.detector import MidiPortPair
 from blocksd.topology.manager import TopologyManager
+
+PORT = MidiPortPair(0, 0, "port")
 
 
 async def test_old_completion_preserves_replacement_group():
@@ -12,11 +15,11 @@ async def test_old_completion_preserves_replacement_group():
     await old
     replacement = asyncio.create_task(asyncio.sleep(0))
     entry = Mock()
-    manager._tasks["port"] = replacement
-    manager._groups["port"] = entry
-    manager._on_group_done("port", old)
-    assert manager._tasks["port"] is replacement
-    assert manager._groups["port"] is entry
+    manager._tasks[PORT] = replacement
+    manager._groups[PORT] = entry
+    manager._on_group_done(PORT, old)
+    assert manager._tasks[PORT] is replacement
+    assert manager._groups[PORT] is entry
     await replacement
 
 
@@ -25,8 +28,8 @@ async def test_cancelled_group_callback_is_safe():
     task = asyncio.create_task(asyncio.sleep(0))
     task.cancel()
     await asyncio.gather(task, return_exceptions=True)
-    manager._tasks["port"] = task
-    manager._on_group_done("port", task)
+    manager._tasks[PORT] = task
+    manager._on_group_done(PORT, task)
     assert not manager._tasks
 
 
@@ -44,10 +47,10 @@ async def test_shutdown_joins_removed_group_cleanup():
             cleaned.set()
 
     task = asyncio.create_task(run())
-    manager._tasks["port"] = task
+    manager._tasks[PORT] = task
     manager._running_tasks.add(task)
     await started.wait()
-    manager._remove_group("port")
+    manager._remove_group(PORT)
     await manager._shutdown()
     assert task.done()
     assert cleaned.is_set()
@@ -69,10 +72,73 @@ async def test_shutdown_does_not_cancel_in_progress_group_cleanup():
             cleaned.set()
 
     task = asyncio.create_task(run())
-    manager._tasks["port"] = task
+    manager._tasks[PORT] = task
     manager._running_tasks.add(task)
     await started.wait()
-    manager._remove_group("port")
+    manager._remove_group(PORT)
     await cleaning.wait()
     await manager._shutdown()
     assert cleaned.is_set()
+
+
+async def test_duplicate_names_keep_independent_groups(monkeypatch):
+    from blocksd.topology import manager as module
+
+    pairs = [MidiPortPair(0, 0, "Lightpad BLOCK"), MidiPortPair(1, 1, "Lightpad BLOCK")]
+    monkeypatch.setattr(module, "scan_for_blocks", lambda: list(pairs))
+
+    async def run_group(_self):
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(module.DeviceGroup, "run", run_group)
+    open_port = Mock(return_value=Mock())
+    monkeypatch.setattr(module, "open_connection", open_port)
+    manager = TopologyManager()
+    try:
+        await manager._scan_cycle()
+        assert len(manager.groups) == 2
+        assert open_port.call_count == 2
+        await manager._scan_cycle()
+        assert open_port.call_count == 2
+        pairs.pop()
+        await manager._scan_cycle()
+        assert len(manager.groups) == 1
+        assert pairs[0] in manager._groups
+    finally:
+        await manager._shutdown()
+
+
+async def test_reindexed_port_releases_old_handle_before_reopening(monkeypatch):
+    from blocksd.topology import manager as module
+
+    old_pair = MidiPortPair(1, 1, "Lightpad BLOCK")
+    new_pair = MidiPortPair(0, 0, "Lightpad BLOCK")
+    pairs = [old_pair]
+    closed = asyncio.Event()
+    started = asyncio.Event()
+
+    async def run_group(_self):
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        finally:
+            await asyncio.sleep(0)
+            closed.set()
+
+    def open_port(*_args, **_kwargs):
+        if pairs == [new_pair]:
+            assert closed.is_set()
+        return Mock()
+
+    monkeypatch.setattr(module, "scan_for_blocks", lambda: list(pairs))
+    monkeypatch.setattr(module, "open_connection", open_port)
+    monkeypatch.setattr(module.DeviceGroup, "run", run_group)
+    manager = TopologyManager()
+    try:
+        await manager._scan_cycle()
+        await started.wait()
+        pairs[:] = [new_pair]
+        await manager._scan_cycle()
+        assert set(manager._groups) == {new_pair}
+    finally:
+        await manager._shutdown()


### PR DESCRIPTION
## 💡 Native macOS support

blocksd can now keep ROLI Blocks connected on macOS through CoreMIDI and run as a per-user LaunchAgent. Linux retains its systemd, udev, and runtime-path behavior. Windows support remains future work.

## 🛠️ Connection and service behavior

The MIDI detector uses CoreMIDI endpoint IDs instead of enumeration indices to identify connections. Unplugging one of two identically named devices no longer replaces the surviving connection when its index changes. Physical input/output ports are paired by owning entity; virtual endpoints cannot consume a physical device's output. Opening a connection checks identity before and after opening the ports.

The macOS installer writes a LaunchAgent with an absolute executable path and per-user logs. Reinstallation waits for launchd to finish unloading the old job before bootstrapping its replacement. The default config lives under Application Support, with legacy config paths retained. A short, owner-only runtime directory avoids macOS Unix-socket path limits and rejects unsafe existing directories.

The CI matrix now covers Linux and macOS on Python 3.13 and 3.14. Installed-wheel checks use a fresh environment so a rebuilt wheel at the same path cannot silently reuse an older installation.

## 🧪 Validation

- All 493 tests passed locally on macOS with Python 3.13 and 3.14. Ruff lint/format, ty, shell syntax, dashboard checks/build, and documentation lint/build passed.
- An installed-wheel smoke test confirmed IPC ping, the bundled HTTP dashboard, and clean signal shutdown.
- Real launchd startup, repeat installation, and uninstall passed using an isolated temporary service.
- Real virtual CoreMIDI endpoints retained their IDs after index changes. Independent review caught and verified the physical/virtual pairing regression.
- User-confirmed hardware operation: USB LUMI Keys and a DNA-connected Lightpad Block M entered API mode and reported topology and battery state.

Sleep/wake and DAW coexistence still need hardware acceptance testing. The existing LittleFoot renderer limitation is unchanged. Homebrew packaging will follow separately; published v0.5.0 does not contain this macOS support.
