### PR TITLE
feat(packaging): build and verify Homebrew releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,18 @@ jobs:
       - run: uv build --clear
       - name: Verify installed distribution
         run: uv run --no-project --no-cache --with dist/*.whl python scripts/check_distribution.py
+      - name: Verify Homebrew installation
+        if: runner.os == 'macOS'
+        env:
+          HOMEBREW_NO_INSTALL_CLEANUP: "1"
+          HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: "1"
+          HOMEBREW_NO_ASK: "1"
+        run: |
+          brew tap-new blocksd/ci
+          uv run --no-project python scripts/generate_homebrew.py dist/blocksd-*.tar.gz \
+            --local --output "$(brew --repository blocksd/ci)/Formula/blocksd.rb"
+          brew install --build-from-source blocksd/ci/blocksd
+          brew test blocksd/ci/blocksd
 
   docs:
     name: Documentation

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -56,8 +56,9 @@ jobs:
         run: |
           mkdir -p release
           cp dist/*.whl dist/*.tar.gz install.sh release/
+          uv run --no-project python scripts/generate_homebrew.py dist/blocksd-*.tar.gz --output release/blocksd.rb
           cd release
-          sha256sum ./*.whl ./*.tar.gz install.sh > SHA256SUMS
+          sha256sum ./*.whl ./*.tar.gz install.sh blocksd.rb > SHA256SUMS
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,7 @@ jobs:
         run: |
           uv lock --check
           uv build --clear
+          uv run --no-project python scripts/generate_homebrew.py dist/blocksd-*.tar.gz --output dist/blocksd.rb
 
       - name: Commit version bump
         if: ${{ !inputs.dry_run }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,3 +99,11 @@ Keep commits focused, include regression tests for behavior changes, and documen
 Run `just check`, merge the changes, then dispatch Release with an explicit version (for example, `0.5.0`). Use its `dry_run` option to exercise preparation without tagging or publishing. The publication workflow generates release notes with git-iris using the Anthropic provider and `claude-opus-5`. Review the generated notes for accurate upgrade instructions and hardware limitations.
 
 The release workflow updates package metadata, builds and verifies distributions, creates a tag, and dispatches publication. The GitHub release includes the wheel, source archive, `install.sh`, and `SHA256SUMS`; PyPI publication uses trusted publishing. Check the release and publish workflow results before announcing availability. The latest installer URL follows the latest GitHub release, while `--version` selects the package version from PyPI.
+
+### Homebrew
+
+Publication also generates `blocksd.rb` from the built source archive. The formula uses that archive's version, checksum, and locked runtime dependency closure, including the bundled dashboard. CI installs the formula from a local archive on macOS and runs `brew test` before release. The source build requires Homebrew Python, Rust, CMake, and pkgconf.
+
+After a macOS-capable release is published, submit its `blocksd.rb` as `Formula/blocksd.rb` in `hyperb1iss/homebrew-tap`. Verify the release asset checksum before opening the tap PR. Do not publish the formula generated from an unreleased local build against an existing release tag.
+
+The shared `homebrew-update.yml` workflow currently accepts native binary artifacts, not Python formulas. Automatic tap updates need a formula-artifact path in that workflow and a `HOMEBREW_TAP_TOKEN` secret with access to the tap. Until configured, update the tap through a reviewed PR; package publication alone does not make a release available through Homebrew.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ uv run --locked blocksd run -v
 
 After stopping the foreground process, run `uv run --locked blocksd install` to install a per-user LaunchAgent that starts on login. macOS does not need udev rules or sudo. Keep the checkout and its virtual environment at the installed path.
 
-The macOS runtime and installer have automated coverage. Hardware handshake, sleep/wake, and DAW coexistence still need validation with connected Blocks. See the [macOS installation guide](https://hyperb1iss.github.io/blocksd/guide/installation#macos) for service commands and the hardware checklist.
+The macOS runtime and installer have automated coverage. USB LUMI Keys and a DNA-connected Lightpad Block M have been confirmed entering API mode. Sleep/wake and DAW coexistence still need hardware validation. See the [macOS installation guide](https://hyperb1iss.github.io/blocksd/guide/installation#macos) for service commands, Homebrew packaging status, and the hardware checklist.
 
 ### Quick Install
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ ROLI Blocks devices need an active host-side handshake over MIDI SysEx to enter 
 
 ### macOS
 
-macOS support is available from source until the next release. Build the dashboard, then run in the foreground:
+macOS requires v0.6.0 or newer. To run from source, build the dashboard and start the daemon in the foreground:
 
 ```bash
 git clone https://github.com/hyperb1iss/blocksd.git
@@ -73,7 +73,7 @@ curl -fsSL https://github.com/hyperb1iss/blocksd/releases/latest/download/instal
 bash install-blocksd.sh
 ```
 
-The current release installer targets Linux. It installs or upgrades blocksd using uv and managed Python, installs udev rules with sudo, and enables and restarts a systemd user service. Run as your normal user. Use `--version 0.5.0` to select a release or `--no-udev`, `--no-service`, and `--no-enable` to skip setup steps. See the [installation guide](https://hyperb1iss.github.io/blocksd/guide/installation) for prerequisites and upgrade details.
+Starting with v0.6.0, the installer supports Linux and macOS. It installs or upgrades blocksd using uv and managed Python. Linux setup installs udev rules with sudo and restarts a systemd user service; macOS setup installs a per-user LaunchAgent without sudo. Run as your normal user. Use `--version 0.6.0` to select a release or `--no-udev`, `--no-service`, and `--no-enable` to skip setup steps. See the [installation guide](https://hyperb1iss.github.io/blocksd/guide/installation) for prerequisites and upgrade details.
 
 ### From PyPI
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -46,7 +46,18 @@ CoreMIDI scanning, runtime startup, and installer behavior can be checked withou
 - Recovery after sleep/wake.
 - Concurrent MIDI use with your DAW. Close ROLI Dashboard during the protocol check so another host does not change API mode.
 
-Hardware acceptance remains pending. The existing LittleFoot renderer limitation also applies on macOS: accepted LED writes do not prove visible output.
+USB LUMI Keys and a DNA-connected Lightpad Block M have been confirmed entering API mode on macOS. Sleep/wake and DAW coexistence still need hardware acceptance testing. The existing LittleFoot renderer limitation also applies on macOS: accepted LED writes do not prove visible output.
+
+### Homebrew packaging
+
+The next release includes a Homebrew formula for `hyperb1iss/tap`. The formula must be merged into the tap before this install path is available:
+
+```bash
+brew install hyperb1iss/tap/blocksd
+blocksd run
+```
+
+After stopping the foreground process, run `blocksd install` to enable startup at login. Homebrew installation does not start a daemon automatically. Run `blocksd install` again after upgrades to refresh the LaunchAgent's executable path. Before `brew uninstall blocksd`, run `blocksd uninstall` to remove the agent.
 
 If python-rtmidi builds from source, install Xcode Command Line Tools (`xcode-select --install`). CoreMIDI is the native backend; ALSA/JACK packages are not needed.
 

--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -4,7 +4,7 @@ blocksd uses ALSA MIDI on Linux and CoreMIDI on macOS, with Python 3.13 or newer
 
 ## macOS
 
-macOS support is available from source until the next release. Follow [From Source](#from-source), or build only the runtime and dashboard:
+macOS requires v0.6.0 or newer. Follow [From Source](#from-source), or build only the runtime and dashboard:
 
 ```bash
 git clone https://github.com/hyperb1iss/blocksd.git
@@ -48,9 +48,9 @@ CoreMIDI scanning, runtime startup, and installer behavior can be checked withou
 
 USB LUMI Keys and a DNA-connected Lightpad Block M have been confirmed entering API mode on macOS. Sleep/wake and DAW coexistence still need hardware acceptance testing. The existing LittleFoot renderer limitation also applies on macOS: accepted LED writes do not prove visible output.
 
-### Homebrew packaging
+### Homebrew Packaging
 
-The next release includes a Homebrew formula for `hyperb1iss/tap`. The formula must be merged into the tap before this install path is available:
+Starting with v0.6.0, releases include a Homebrew formula for `hyperb1iss/tap`. The formula must be merged into the tap before this install path is available:
 
 ```bash
 brew install hyperb1iss/tap/blocksd
@@ -63,7 +63,7 @@ If python-rtmidi builds from source, install Xcode Command Line Tools (`xcode-se
 
 ## Quick Install and Upgrade
 
-The current published release installer targets Linux. Use the source instructions above for macOS until a release includes the new installer.
+The release installer supports Linux and macOS starting with v0.6.0. Earlier installers target Linux only.
 
 Download the release installer, inspect it, and run it as your normal user:
 
@@ -73,12 +73,12 @@ less install-blocksd.sh
 bash install-blocksd.sh
 ```
 
-The installer installs or upgrades the latest PyPI release in an isolated uv tool environment, installs udev rules (using sudo), and enables and restarts the systemd user service. Re-running the same command upgrades an existing installation.
+The installer installs or upgrades the latest PyPI release in an isolated uv tool environment. On Linux it installs udev rules (using sudo) and enables and restarts the systemd user service. On macOS it installs and starts a per-user LaunchAgent without sudo. Re-running the same command upgrades an existing installation.
 
 To select a release or skip parts of setup:
 
 ```bash
-bash install-blocksd.sh --version 0.5.0
+bash install-blocksd.sh --version 0.6.0
 bash install-blocksd.sh --no-udev
 bash install-blocksd.sh --no-service
 bash install-blocksd.sh --no-enable

--- a/packaging/homebrew/blocksd.rb.in
+++ b/packaging/homebrew/blocksd.rb.in
@@ -1,0 +1,49 @@
+class Blocksd < Formula
+  include Language::Python::Virtualenv
+
+  desc "ROLI Blocks device discovery, keepalive, and control"
+  homepage "https://github.com/hyperb1iss/blocksd"
+  url "https://github.com/hyperb1iss/blocksd/releases/download/v@VERSION@/blocksd-@VERSION@.tar.gz"
+  version "@VERSION@"
+  sha256 "@SHA256@"
+  license "ISC"
+
+  depends_on "cmake" => :build
+  depends_on "pkgconf" => :build
+  depends_on "rust" => :build
+  depends_on :macos
+  depends_on "python@3.14"
+
+@RESOURCES@
+
+  def install
+    virtualenv_install_with_resources
+  end
+
+  def caveats
+    <<~EOS
+      Run blocksd in the foreground:
+        blocksd run
+
+      After stopping the foreground process, enable startup at login:
+        blocksd install
+
+      Run blocksd install again after upgrading to refresh the LaunchAgent.
+      Before removing blocksd, run blocksd uninstall to remove the agent.
+      Do not use sudo for these commands.
+    EOS
+  end
+
+  test do
+    assert_match "ROLI Blocks", shell_output("#{bin}/blocksd --help")
+    system libexec/"bin/python", "-c", <<~PYTHON
+      import rtmidi
+      from importlib.metadata import version
+      from blocksd.web import resolve_static_dir
+      assert version("blocksd") == "#{version}"
+      assert rtmidi.API_MACOSX_CORE in rtmidi.get_compiled_api()
+      index = resolve_static_dir() / "index.html"
+      assert index.is_file(), "Bundled dashboard is missing"
+    PYTHON
+  end
+end

--- a/scripts/generate_homebrew.py
+++ b/scripts/generate_homebrew.py
@@ -1,0 +1,127 @@
+"""Generate a release formula from the built sdist and locked runtime dependencies."""
+
+import argparse
+import hashlib
+import re
+import tarfile
+import tomllib
+from pathlib import Path
+from typing import TypedDict
+
+
+class Dependency(TypedDict):
+    """Dependency identity from the uv lockfile."""
+
+    name: str
+
+
+class SourceArchive(TypedDict):
+    """A checksummed source archive from the lockfile."""
+
+    url: str
+    hash: str
+
+
+class Package(TypedDict):
+    """Fields consumed from a locked package."""
+
+    name: str
+    version: str
+    dependencies: list[Dependency]
+    sdist: SourceArchive
+
+
+def runtime_resources(packages: list[Package]) -> str:
+    """Include the runtime closure, rejecting ambiguous package versions."""
+    by_name = {package["name"]: package for package in packages}
+    if len(by_name) != len(packages):
+        raise ValueError("Multiple versions of a package require explicit platform resolution")
+    pending = [dep["name"] for dep in by_name["blocksd"].get("dependencies", [])]
+    selected: set[str] = set()
+    while pending:
+        name = pending.pop()
+        if name in selected:
+            continue
+        selected.add(name)
+        pending.extend(dep["name"] for dep in by_name[name].get("dependencies", []))
+
+    resources = []
+    for name in sorted(selected):
+        source = by_name[name]["sdist"]
+        url, checksum = source["url"], source["hash"]
+        if not re.fullmatch(r"[a-z0-9][a-z0-9-]*", name):
+            raise ValueError(f"Unsafe package name: {name}")
+        if not re.fullmatch(r"https://files\.pythonhosted\.org/[A-Za-z0-9/_.+-]+", url):
+            raise ValueError(f"Unsafe source URL for {name}")
+        if not re.fullmatch(r"sha256:[a-f0-9]{64}", checksum):
+            raise ValueError(f"Invalid source checksum for {name}")
+        resources.append(
+            f'  resource "{name}" do\n'
+            f'    url "{url}"\n'
+            f'    sha256 "{checksum.removeprefix("sha256:")}"\n'
+            "  end"
+        )
+    return "\n\n".join(resources)
+
+
+def generate_formula(sdist: Path, template: Path) -> str:
+    """Use the archive's own metadata and lockfile, never the checkout's version."""
+    with tarfile.open(sdist) as archive:
+        roots = {member.name.split("/")[0] for member in archive.getmembers()}
+        if len(roots) != 1:
+            raise ValueError("Expected one source archive root")
+        root = roots.pop()
+
+        def read_member(name: str) -> bytes:
+            member = archive.getmember(f"{root}/{name}")
+            if not member.isfile():
+                raise ValueError(f"Expected regular archive member: {name}")
+            contents = archive.extractfile(member)
+            if contents is None:
+                raise ValueError(f"Missing archive member: {name}")
+            return contents.read()
+
+        project = tomllib.loads(read_member("pyproject.toml").decode())["project"]
+        lock = tomllib.loads(read_member("uv.lock").decode())
+        read_member("src/blocksd/web/static/index.html")
+
+    version = project["version"]
+    if project["name"] != "blocksd" or not re.fullmatch(r"\d+\.\d+\.\d+", version):
+        raise ValueError("Expected a stable blocksd release")
+    if sdist.name != f"blocksd-{version}.tar.gz":
+        raise ValueError("Archive filename does not match its package version")
+    locked = [package for package in lock["package"] if package["name"] == "blocksd"]
+    if len(locked) != 1 or locked[0]["version"] != version:
+        raise ValueError("Archive lockfile does not match its package version")
+    return (
+        template.read_text()
+        .replace("@VERSION@", version)
+        .replace("@SHA256@", hashlib.sha256(sdist.read_bytes()).hexdigest())
+        .replace("@RESOURCES@", runtime_resources(lock["package"]))
+    )
+
+
+def main() -> None:
+    """Write the formula next to the release distributions."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sdist", type=Path)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument(
+        "--local", action="store_true", help="Use the local archive URL for build verification"
+    )
+    args = parser.parse_args()
+    template = Path(__file__).resolve().parents[1] / "packaging/homebrew/blocksd.rb.in"
+    formula = generate_formula(args.sdist, template)
+    if args.local:
+        formula = re.sub(
+            r'^  url "https://github.com/hyperb1iss/blocksd/releases/[^"\n]+"$',
+            f'  url "{args.sdist.resolve().as_uri()}"',
+            formula,
+            count=1,
+            flags=re.MULTILINE,
+        )
+    args.output.write_text(formula)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_homebrew.py
+++ b/tests/test_homebrew.py
@@ -1,0 +1,88 @@
+"""Release formula generation must use the built archive and runtime lock closure."""
+
+import hashlib
+import io
+import subprocess
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def make_sdist(tmp_path: Path, *, dashboard: bool = True, lock_version: str = "0.6.0") -> Path:
+    """Create a small archive with an unused dev package and a transitive dependency."""
+    files = {
+        "pyproject.toml": '[project]\nname = "blocksd"\nversion = "0.6.0"\n',
+        "uv.lock": f'''
+[[package]]
+name = "blocksd"
+version = "{lock_version}"
+dependencies = [{{name = "runtime"}}]
+[[package]]
+name = "runtime"
+version = "1.0.0"
+dependencies = [{{name = "transitive"}}]
+sdist = {{url = "https://files.pythonhosted.org/runtime-1.0.0.tar.gz", hash = "sha256:{"a" * 64}"}}
+[[package]]
+name = "transitive"
+version = "2.0.0"
+sdist = {{url = "https://files.pythonhosted.org/transitive-2.0.0.tar.gz", hash = "sha256:{"b" * 64}"}}
+[[package]]
+name = "unused-dev"
+version = "3.0.0"
+''',
+    }
+    if dashboard:
+        files["src/blocksd/web/static/index.html"] = "<html>dashboard</html>"
+    path = tmp_path / "blocksd-0.6.0.tar.gz"
+    with tarfile.open(path, "w:gz") as archive:
+        for name, text in files.items():
+            data = text.encode()
+            member = tarfile.TarInfo(f"blocksd-0.6.0/{name}")
+            member.size = len(data)
+            archive.addfile(member, io.BytesIO(data))
+    return path
+
+
+def generate(path: Path, output: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(  # noqa: S603 - fixed interpreter and repository-owned generator
+        [
+            sys.executable,
+            str(ROOT / "scripts/generate_homebrew.py"),
+            str(path),
+            "--output",
+            str(output),
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+def test_formula_uses_archive_version_checksum_and_runtime_closure(tmp_path: Path) -> None:
+    path = make_sdist(tmp_path)
+    output = tmp_path / "blocksd.rb"
+    result = generate(path, output)
+    assert result.returncode == 0, result.stderr
+    formula = output.read_text()
+    assert 'version "0.6.0"' in formula
+    assert hashlib.sha256(path.read_bytes()).hexdigest() in formula
+    assert 'resource "runtime"' in formula
+    assert 'resource "transitive"' in formula
+    assert "unused-dev" not in formula
+    assert "@VERSION@" not in formula
+    assert "@RESOURCES@" not in formula
+    assert "virtualenv_install_with_resources" in formula
+
+
+@pytest.mark.parametrize(("dashboard", "lock_version"), [(False, "0.6.0"), (True, "0.5.0")])
+def test_invalid_sdist_does_not_publish_formula(
+    tmp_path: Path, dashboard: bool, lock_version: str
+) -> None:
+    path = make_sdist(tmp_path, dashboard=dashboard, lock_version=lock_version)
+    output = tmp_path / "blocksd.rb"
+    assert generate(path, output).returncode != 0
+    assert not output.exists()


### PR DESCRIPTION
## 💡 Build a Homebrew formula with each release

macOS support is merged, but the tap needs a Python package with its dashboard and native MIDI dependency. Releases now generate a checksum-pinned Homebrew formula from the built source archive. The release workflow's CI gate installs that formula on macOS and runs its package tests before tagging; publication repeats the gate at the release tag.

## 🛠️ Packaging contract

The generator reads the archive's own package version and lockfile, follows the runtime dependency closure, and writes source-resource checksums into the formula. Missing dashboard content, mismatched versions, ambiguous locked versions, and unsafe resource fields fail generation. Build backends still use Homebrew's normal isolated builds; this is not a fully hermetic build.

The formula uses Homebrew's Python virtualenv support with Python 3.14, Rust, CMake, and pkgconf. Installation does not start a service. Users explicitly run `blocksd install` after stopping a foreground instance and repeat that command after upgrades to refresh the LaunchAgent path.

Publication attaches `blocksd.rb` and includes it in `SHA256SUMS`. The current shared tap updater only accepts native binary artifacts, so the first formula will enter `hyperb1iss/homebrew-tap` through a separate PR after v0.6.0 is published. Automatic updates need shared-workflow support for formula artifacts and the tap token; this PR does not claim to enable them.

## 🧪 Validation

- All 496 Python tests passed locally, including archive-version/checksum/runtime-closure tests and rejection of incomplete or mismatched archives. Ruff lint/format, ty, documentation lint/build, and workflow YAML parsing passed.
- A real Homebrew source build on Apple Silicon installed the generated formula into an unlinked temporary-tap keg (14.3 MB). The installed CLI, CoreMIDI extension, package version, and bundled dashboard passed `brew test --force`.
- The existing distribution verifier also passed against the Homebrew-installed Python environment, not the checkout.
- Independent consumer review caught an unsupported `--version` invocation in the formula test. The corrected test exercises CLI help and reads the installed package version through Python metadata.

The local build uses the unreleased checkout's 0.5.0 archive only for verification. No formula pointing to the existing v0.5.0 release has been published. Availability through the tap follows the new release and its tap PR.
