### PR TITLE
feat(lighting): enable Lightpad rendering and LUMI key colors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,7 +271,7 @@ Protocol, device, topology, daemon, API, CLI, and dashboard layers are implement
 
 CLI commands live in `cli/app.py`, `cli/led.py`, `cli/config.py`, and `cli/install.py`. LED/config commands open independent MIDI sessions; they are not socket clients. Stop the service before running them.
 
-LittleFoot program upload is disabled, including the unreachable unrolled fill fallback. Accepted LED frames confirm heap writes, not visible rendering. Config timing fields are not forwarded to the runtime.
+LED programs load on the first frame. Wait for complete program ACK, then a matching nonce reply from handleMessage before publishing pixels (firmware initialisation can clear preloaded pixel data). Both renderers disable the status overlay; the LUMI renderer retains default musical handling with setUseDefaultKeyHandler(true, false). Visible RGB patterns were confirmed on Lightpad M 1.1.0 and LUMI 1.3.9; live MIDI/MPE preservation and sustained timing remain unverified. Accepted API frames confirm daemon acceptance, not visible rendering. Config timing fields are not forwarded to the runtime.
 
 Use `just install` for locked Python, dashboard, and documentation dependencies. Run `just check` for Python lint/types/tests, dashboard checks, documentation build, and installed-wheel verification. Dashboard and docs use pnpm. See CONTRIBUTING.md for individual commands and release requirements.
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ROLI Blocks devices need an active host-side handshake over MIDI SysEx to enter 
 | 🔌 **API Mode Keepalive**    | Periodic pings prevent the 5-second device timeout that kills API mode                          |
 | 🏗️ **Topology Management**   | Auto-discovers devices over USB, tracks DNA-connected blocks through master                     |
 | 🎭 **Full State Machine**    | Serial → topology → API activation → ping loop, matching the C++ reference                      |
-| 💡 **LED Control**           | Lightpad / Lightpad M RGB565 bitmap grid, CLI patterns (solid, gradient, rainbow, checkerboard) |
+| 💡 **LED Control**           | Lightpad RGB565 grids and LUMI per-key colors, with CLI patterns |
 | 👆 **Touch & Button Events** | Normalized touch data (x/y/z/velocity) and button callbacks                                     |
 | ⚙️ **Device Config**         | Read/write device settings (sensitivity, MIDI channel, scale, etc.)                             |
 | 🔊 **DAW Friendly**          | ALSA multi-client, blocksd and your DAW share MIDI without conflict                             |
@@ -104,7 +104,7 @@ The `install` command sets up:
 
 ## ⚡ Usage
 
-The current daemon does not upload its LittleFoot LED renderer (firmware opcode compatibility remains unresolved). LED commands and API frames can update heap data, but an accepted write does not establish visible LED output. See the [LittleFoot notes](https://hyperb1iss.github.io/blocksd/architecture/littlefoot).
+The first LED frame loads a device-side LittleFoot renderer. The daemon waits for complete upload acknowledgement and a matching reply to a fresh execution challenge before sending pixels. Visible RGB patterns have been verified on Lightpad Block M firmware 1.1.0 and LUMI Keys firmware 1.3.9. An accepted API frame confirms daemon acceptance, not a visible display change. See the [LittleFoot notes](https://hyperb1iss.github.io/blocksd/architecture/littlefoot) for the hardware evidence and remaining checks.
 
 ### Running the Daemon
 
@@ -154,7 +154,15 @@ blocksd led gradient ff0000 0000ff                    # horizontal gradient
 blocksd led gradient ff0000 0000ff --vertical         # vertical gradient
 blocksd led checkerboard ff0000 00ff00                # 1x1 checkerboard
 blocksd led checkerboard ff0000 00ff00 --size 3       # 3×3 checkerboard
-blocksd led off                                       # lights off
+blocksd led off                                       # Lightpad lights off
+```
+
+Control all 24 LUMI key colors (firmware 1.3.0 or newer):
+
+```bash
+blocksd led keys                       # rainbow across the keys
+blocksd led keys '#ff00ff'              # one color on every key
+blocksd led keys 000000                 # key lights off
 ```
 
 ### Device Configuration
@@ -206,9 +214,9 @@ blocksd uninstall                      # remove service and udev rules
 The quick rules:
 
 - Use `discover` first to get the device `uid`
-- Only stream frames to devices advertising nonzero `grid_width` and
-  `grid_height` in discovery
-- Use the fixed-size binary frame protocol for animation and streaming
+- Use bitmap frames for devices with nonzero `grid_width` and `grid_height`
+- Use JSON `key_frame` for LUMI devices with `key_count = 24`
+- Use the fixed-size binary frame protocol for Lightpad animation and streaming
 - Treat `frame_ack.accepted=false` or binary ack `0x00` as a rejected write:
   this usually means the device is not ready yet, the `uid` is gone, or the
   payload was malformed
@@ -248,7 +256,7 @@ blocksd
 ├── littlefoot/
 │   ├── opcodes.py            LittleFoot VM opcode definitions
 │   ├── assembler.py          bytecode assembler with label support
-│   └── programs.py           BitmapLEDProgram (100-byte repaint)
+│   └── programs.py           BitmapLEDProgram (145 bytes)
 ├── topology/
 │   ├── detector.py           MIDI port scanning
 │   ├── device_group.py       connection lifecycle (the big one)
@@ -304,9 +312,10 @@ Host                                          Device
 | Touch Block             | Unknown             | `TCB`         | 🔲 Untested |
 | Seaboard RISE 25/49     | `0x0200` / `0x0210` | N/A           | 🔲 Untested |
 
-Bitmap LED streaming is currently exposed for Lightpad Block / Lightpad Block M
-only. Other devices are still discoverable and supported by the topology/API
-state machine, but they do not advertise a bitmap frame surface.
+Lightpad Block / Lightpad Block M expose a 15×15 bitmap surface. LUMI Keys
+exposes 24 key colors through a separate key-frame API. Visible RGB patterns
+were confirmed on Lightpad M 1.1.0 and LUMI 1.3.9 on September 7, 2026. Other
+recognized Blocks can use discovery and keepalive; their lighting is unverified.
 
 ## 🧪 Development
 
@@ -330,7 +339,7 @@ See [VISION.md](VISION.md) for the full vision, use cases, and ideas beyond musi
 - [x] **API Mode Keepalive**: full state machine with correct ping timing
 - [x] **Remote Heap Manager**: ACK tracking, retransmission, heap state sync
 - [x] **LittleFoot Assembler**: bytecode generation and BitmapLEDProgram definition
-- [ ] **LittleFoot Upload**: firmware-compatible renderer for visible LED output
+- [x] **LittleFoot Upload**: execution-ready handshake for Lightpad and LUMI renderers
 - [x] **CLI LED Commands**: `blocksd led solid '#ff00ff'`, `blocksd led rainbow`
 - [x] **Touch/Button Events**: normalized callbacks with full velocity data
 - [x] **Config Commands**: read/write device settings via CLI

--- a/VISION.md
+++ b/VISION.md
@@ -8,7 +8,7 @@
 
 **blocksd** is a Linux daemon that brings full ROLI Blocks support to Linux. ROLI's official software is Windows/macOS only. On Linux, these devices show a searching animation and eventually power off since there's no host-side driver to activate API mode.
 
-We're building the full protocol stack: device discovery, topology management, API mode keepalive, LED control, touch/pressure input, and eventually LittleFoot program upload. The goal is complete parity with the original ROLI drivers, plus capabilities they never shipped.
+We're building the full protocol stack: device discovery, topology management, API mode keepalive, LED control, touch/pressure input, and LittleFoot LED renderer upload. The goal is complete parity with the original ROLI drivers, plus capabilities they never shipped.
 
 ### What Makes These Devices Special
 
@@ -97,7 +97,7 @@ A physical, tactile interface for home automation.
 
 ---
 
-These are proposed applications, not bundled features. The current daemon skips LittleFoot renderer upload, so LED-based ideas depend on resolving firmware compatibility first. Unix socket and WebSocket APIs already provide discovery and event subscriptions.
+These are proposed applications, not bundled features. Lightpad grid rendering and LUMI per-key colors are available through device-side LittleFoot programs. Unix socket and WebSocket APIs provide discovery and event subscriptions; each application still needs its own integration and hardware checks.
 
 ## 🧪 Experimental Ideas
 
@@ -132,7 +132,7 @@ The devices run LittleFoot, a simple bytecode VM. Programs uploaded to the devic
 
 ### WebSocket / HTTP API
 
-The HTTP dashboard and WebSocket device API exist today. Webhooks, classroom orchestration, and visible LED rendering still need further work:
+The HTTP dashboard, WebSocket device API, and device-side LED renderers exist today. Webhooks, classroom orchestration, and browser painting controls still need further work:
 
 - **Web dashboard**: real-time device status, battery, topology visualization
 - **Remote LED control**: paint on the grid from a phone browser
@@ -154,7 +154,7 @@ The HTTP dashboard and WebSocket device API exist today. Webhooks, classroom orc
 - [x] **DataChange Encoder**: diff-based heap writes with RLE
 - [x] **systemd/udev**: user service, device rules, install/uninstall CLI
 - [x] **Remote Heap Manager**: ACK-tracked heap state, retransmission, in-flight budgets
-- [x] **LittleFoot Assembler**: bytecode assembler with label resolution and FNV1a function hashing
+- [x] **LittleFoot Assembler**: bytecode assembler with program-relative label resolution and native function hashing
 - [x] **CLI LED Commands**: `blocksd led solid '#ff00ff'`, rainbow, gradient, checkerboard
 - [x] **Touch & Button Events**: normalized pressure/velocity callbacks
 - [x] **Config Commands**: device settings read/write via CLI
@@ -162,10 +162,11 @@ The HTTP dashboard and WebSocket device API exist today. Webhooks, classroom orc
 - [x] **Unix Socket API**: NDJSON + binary frame protocol for external clients
 - [x] **WebSocket & HTTP API**: browser-based control, monitoring, and LED streaming
 - [x] **Web Dashboard**: `blocksd ui` launches a real-time device status interface
+- [x] **LittleFoot LED Renderers**: Lightpad bitmap and LUMI key colors, with execution-ready startup and visible RGB validation on Lightpad M 1.1.0 / LUMI 1.3.9
 
 ### In Progress
 
-- [ ] **LittleFoot Program Upload**: BitmapLEDProgram bytecode to device memory (blocked by firmware opcode incompatibility on v1.1.0; `getHeapBits` and `dupOffset` crash the VM; assembler and programs are complete, upload is disabled pending firmware fix)
+- [ ] **Hardware Acceptance Coverage**: live MIDI/MPE preservation during LUMI lighting, sustained frame timing, reconnect behavior, and color calibration
 
 ### Planned
 

--- a/docs/architecture/data-flow.md
+++ b/docs/architecture/data-flow.md
@@ -84,7 +84,7 @@ graph TD
     DEV -->|ACK| NEXT[Next diff from<br/>current target]
 ```
 
-When the client sends frames faster than the device can accept them, the heap manager doesn't queue them up. It always diffs against the latest target state, which means intermediate frames are automatically skipped. The target heap converges as packets are acknowledged. Visible rendering also requires a compatible LittleFoot program, which the current daemon does not upload.
+The heap manager coalesces frames into the latest target state. Intermediate frames can be skipped while packets are awaiting acknowledgement. During startup, the latest frame stays queued until the complete code transfer is acknowledged and the LittleFoot renderer answers a fresh execution challenge. Subsequent frames update the pixel heap for device-side repaint.
 
 ## Keepalive Flow
 

--- a/docs/architecture/littlefoot.md
+++ b/docs/architecture/littlefoot.md
@@ -1,108 +1,83 @@
 # LittleFoot VM
 
-ROLI Blocks devices run LittleFoot, a bytecode virtual machine baked into the firmware. Programs uploaded to the device execute locally in the firmware VM, enabling LED rendering and touch processing without USB round-trips. This is how ROLI's own software achieves responsive LED feedback: the host writes pixel data to the device heap, and a LittleFoot program reads it and calls `fillPixel()` on each repaint cycle.
+ROLI Blocks run LittleFoot, a bytecode virtual machine in the firmware. The host uploads a renderer and sends pixel data to its heap. The renderer calls `fillPixel()` during device-side repaint callbacks.
 
-## Architecture
+## Renderer Startup
 
-blocksd includes a complete LittleFoot assembler that generates valid program binaries from instruction sequences. The assembler handles label resolution, function table generation, and program checksum computation.
+The daemon loads a renderer when it accepts the first frame for a supported device. Discovery and keepalive alone leave the device's existing program in place.
 
-```mermaid
-graph LR
-    ASM[Assembly Instructions] --> ASSEMBLE[Assembler]
-    ASSEMBLE --> BIN[Program Binary]
-    BIN --> DC[Data Change Encoder]
-    DC --> HEAP[Device Heap Upload]
-    HEAP --> VM[LittleFoot VM on Device]
-```
+Startup follows this sequence:
+
+1. Upload the renderer with an empty pixel heap. Initialisation disables the status overlay; LUMI also retains its default musical handler.
+2. Wait for acknowledgement of the complete code transfer.
+3. Send a fresh execution challenge to the renderer's `handleMessage()` callback.
+4. Accept only the matching reply, then publish the latest queued pixel frame. Subsequent frames update the pixel heap directly.
+
+The challenge and reply each contain three integers: `(0x424C4544, renderer_kind, nonce)`. Renderer kind `1` identifies the Lightpad bitmap program; kind `2` identifies the LUMI key program. The nonce is a positive signed 32-bit value refreshed whenever confirmed heap state is lost. LUMI initialisation calls `setUseDefaultKeyHandler(true, false)` (retain musical key handling, replace lighting).
+
+An unanswered challenge is retried without reuploading the program. The message callback can answer even if identical program bytes survive a reconnect without another initialisation callback. When confirmed heap state is lost, the daemon clears readiness, rotates the nonce, and restarts the code-only transfer while retaining the latest requested pixels. Replies from the previous transfer cannot release those pixels.
+
+An accepted API frame confirms daemon acceptance. The frame can remain queued during renderer startup. Neither API acceptance nor a device packet ACK establishes visible rendering.
+
+## Programs and Pixel Layout
+
+| Surface               | Program size | Pixel heap        | Device coordinates          |
+| --------------------- | ------------ | ----------------- | --------------------------- |
+| Lightpad / Lightpad M | 145 bytes    | 450 bytes, RGB565 | 15×15 grid                  |
+| LUMI Keys             | 130 bytes    | 48 bytes, RGB565  | 24 keys at `(key_index, 0)` |
+
+Both programs expose `initialise()`, `repaint()`, and `handleMessage()`. Pixel data begins immediately after the program binary. Each little-endian 16-bit pixel stores red in bits 0 to 4, green in bits 5 to 10, and blue in bits 11 to 15. Repaint expands these channels to 8-bit values with shifts of 3, 2, and 3 bits respectively.
+
+LUMI does not expose the SDK's bitmap LEDGrid capability. Its key lighting uses `fillPixel(colour, key_index, 0)`, following the vendor's LittleFoot example. The separate key-frame API preserves that distinction.
 
 ## Program Binary Format
 
-```
+```text
 Offset 0-1:  uint16 LE  checksum
-Offset 2-3:  uint16 LE  program size (bytes, including header)
+Offset 2-3:  uint16 LE  program size, including header
 Offset 4-5:  uint16 LE  number of functions
 Offset 6-7:  uint16 LE  number of globals
 Offset 8-9:  uint16 LE  heap size
-Offset 10+:  function table (4 bytes each: int16 func_id + uint16 code_offset)
+Offset 10+:  function table (int16 function ID + uint16 code address)
 Remaining:   bytecode
 ```
 
-The checksum algorithm: `n = programSize; for each byte from index 2: n = (3*n + byte) & 0xFFFF`. The device validates this before executing.
+The checksum algorithm is `n = programSize; for each byte from index 2: n = (3*n + byte) & 0xFFFF`. Function addresses and jump targets are relative to the complete program binary, including the header and function table.
 
-## Native Functions
+Native function IDs use the SDK's multiply-by-31 signature hash. The return-type character after `/` is excluded; the signature length is added before retaining the low 16 bits. Native calls push arguments right to left. Callback IDs use the same hashing convention.
 
-LittleFoot programs call native device functions by their hashed name (FNV1a of the signature string).
+| Signature        | Function ID |
+| ---------------- | ----------- |
+| `makeARGB/iiiii` | `0x3F83`    |
+| `fillPixel/viii` | `0xC20B`    |
+| `repaint/v`      | `0x6F8D`    |
 
-| Function         | ID                | Verified |
-| ---------------- | ----------------- | -------- |
-| `makeARGB/iiiii` | `0x3F83` (16259)  | ✅       |
-| `fillPixel/viii` | `0xC20B` (-15861) | ✅       |
-| `repaint/v`      | `0x6F8D` (28557)  | ✅       |
+## What Hardware Testing Established
 
-These functions are called via the `callNative` opcode with the function's 16-bit hash as the operand.
+On September 7, 2026, visible red and repeating RGB patterns were confirmed on a USB-connected LUMI Keys running firmware 1.3.9 and a DNA-connected Lightpad Block M running firmware 1.1.0. An instrumented bitmap program also completed all 225 pixel iterations on hardware. Both devices answered fresh execution challenges after simulated host heap-state loss while their unchanged programs remained on-device. The subsequent pixel transfers were acknowledged. Physical cable and power-cycle recovery still need separate checks.
 
-## BitmapLEDProgram
+The unchanged upstream C++ LittleFoot runner executes both renderer binaries. Native callback checks verify challenge replies, rejection of unrelated messages, status-overlay settings, LUMI handler arguments, and each pixel's coordinates and logical RGB565 color across repeated repaint calls.
 
-The primary use case for LittleFoot in blocksd is the BitmapLEDProgram: a 100-byte repaint routine that reads RGB565 pixel data from the heap and calls `fillPixel()` for each of the 225 pixels on the Lightpad's 15x15 grid.
+These checks do not establish calibrated physical colors, sustained frame rate, latency, or compatibility with every firmware version. The LUMI renderer requests preservation of musical handling, but a live MIDI/MPE exercise during lighting remains pending. Key rendering requires firmware 1.3.0 or newer (the documented minimum for separate musical and lighting handler switches).
 
-This is the same approach used by the ROLI SDK. The host writes pixel data to the device heap via SharedDataChange, and the LittleFoot program renders it on each repaint cycle.
+## Causes of the Earlier Rendering Failure
 
-## Firmware Compatibility
+### Incorrect Jump Addresses
 
-::: warning
-The LittleFoot program upload is currently disabled due to opcode incompatibilities with Lightpad Block M firmware v1.1.0.
-:::
+The assembler previously encoded jumps relative to the bytecode section. The VM interpreted them relative to the complete program binary. The original bitmap program reproduced an illegal-instruction error in the upstream C++ runner after drawing one pixel. Relocating jump targets by the header and function-table size allowed all 225 pixels to render correctly.
 
-### Known Working Opcodes
+Earlier reports attributed those errors to incompatible `dupOffset` and `getHeapBits` opcodes. Those reports did not isolate firmware incompatibility; the host's incorrect jump addresses were sufficient to reproduce the failure. The current renderer uses the SDK opcode map.
 
-| Byte   | Name        | Verified                 |
-| ------ | ----------- | ------------------------ |
-| `0x00` | halt        | ✅                       |
-| `0x01` | jump        | ✅ (loop back-jumps)     |
-| `0x03` | jumpIfFalse | ✅ (loop conditionals)   |
-| `0x05` | retVoid     | ✅                       |
-| `0x07` | callNative  | ✅ (makeARGB, fillPixel) |
-| `0x08` | drop        | ✅                       |
-| `0x0B` | push0       | ✅                       |
-| `0x0C` | push1       | ✅                       |
-| `0x0D` | push8       | ✅                       |
-| `0x0E` | push16      | ✅                       |
-| `0x10` | dup         | ✅                       |
+### Pixel Data Lost During Startup
 
-### Known Broken Opcodes
+Hardware probes read zeroes from pixel data uploaded alongside program code. A later pixel-only white frame produced the expected byte values. The startup handshake now delays the first pixel upload until the complete code transfer is acknowledged and the renderer answers the current execution challenge.
 
-| Byte   | Name         | Result                                                  |
-| ------ | ------------ | ------------------------------------------------------- |
-| `0x11` | dupOffset_01 | **Illegal instruction**, program aborted                |
-| `0x40` | getHeapBits  | **Illegal instruction**, BitmapLEDProgram requires this |
+### Status Overlay
 
-The firmware's opcode table differs from the ROLI JUCE SDK source. Opcodes `0x11` and `0x40` are critical for the standard BitmapLEDProgram but crash the VM on firmware v1.1.0.
+A minimal green test rendered visibly over the existing background. Disabling the device's status overlay allowed the uploaded renderer to control the full surface. Both renderer initialisers disable that overlay.
 
-### Workaround
+### Heap Synchronisation and DNA Forwarding
 
-An unrolled `fillPixel` test program exists in the source, but the loader returns before uploading it. The daemon currently uploads neither that fallback nor BitmapLEDProgram. The LED frame API still accepts and transfers RGB565 heap data; a successful frame acknowledgement confirms acceptance by the daemon, not visible rendering. A compatible renderer must be uploaded before heap changes can reliably drive the display.
+Unknown heap bytes must differ from every target value, including zero. The diff engine maps unknown bytes to `target[i] ^ 0xFF` so the first transfer replaces stale memory.
 
-## Key Bugs Discovered
-
-### RemoteHeap Full Heap Sync
-
-Unknown device bytes (uint16 `0x100`) were mapped to `0x00` in the expected state computation. When the target was also `0x00`, the diff engine skipped those bytes, leaving stale data in the device heap. Fix: map unknown bytes to `target[i] ^ 0xFF`, guaranteeing they always diff.
-
-### DNA Bridge Requires API Mode on All Devices
-
-Messages addressed to a DNA-connected Lightpad weren't delivered unless the USB-connected LUMI Keys was also in API mode. The daemon already handles this by activating API mode on all devices in the topology.
-
-### Initial TOS Value
-
-The VM initializes `tos = 0` before calling `repaint()`. The first push operation flushes this value onto the stack, creating an extra entry that shifts all `dup_offset` references. Historical probes used unrolled code; the daemon does not currently upload that code.
-
-## Future Work
-
-The right long-term fix is to probe the actual opcode table on each firmware version by uploading small test programs and checking for illegal instruction errors. Once the real opcode map is known, BitmapLEDProgram can be rewritten to use the correct opcodes.
-
-Key unknowns to resolve:
-
-- Is `getHeapByte` (`0x3E`) available on v1.1.0?
-- What is the actual opcode for `dupOffset(int8)`?
-- Do loops work with the correct opcodes?
-- What is the max ops per repaint call?
+The USB-connected bridge must remain in API mode to forward messages to DNA-connected devices. The daemon activates and keeps alive every device in the topology.

--- a/docs/architecture/littlefoot.md
+++ b/docs/architecture/littlefoot.md
@@ -100,3 +100,5 @@ The USB-connected bridge must remain in API mode to forward messages to DNA-conn
 When new frames replaced the heap target during multipart uploads, each packet could start again at the newest changed prefix. A live rainbow sweep exposed the result: only the upper Lightpad rows moved. Completing an immutable transfer snapshot before selecting the newest target restores progress across the whole surface.
 
 Repainting directly from the receiving bank could still mix rows from different frames. The buffered renderer keeps the visible bank immutable until its successor has been fully uploaded and repainted.
+
+Incoming MIDI messages are processed independently of the 200 ms lifecycle timer. The receive loop waits for either a packet or the next timer deadline. Sleeping between receive batches would delay heap and presentation acknowledgements and can trigger unnecessary retransmissions.

--- a/docs/architecture/littlefoot.md
+++ b/docs/architecture/littlefoot.md
@@ -11,24 +11,37 @@ Startup follows this sequence:
 1. Upload the renderer with an empty pixel heap. Initialisation disables the status overlay; LUMI also retains its default musical handler.
 2. Wait for acknowledgement of the complete code transfer.
 3. Send a fresh execution challenge to the renderer's `handleMessage()` callback.
-4. Accept only the matching reply, then publish the latest queued pixel frame. Subsequent frames update the pixel heap directly.
+4. Accept only the matching reply, then publish the latest queued pixel frame. LUMI frames update their pixel heap directly. Lightpad frames use the bank presentation protocol below.
 
 The challenge and reply each contain three integers: `(0x424C4544, renderer_kind, nonce)`. Renderer kind `1` identifies the Lightpad bitmap program; kind `2` identifies the LUMI key program. The nonce is a positive signed 32-bit value refreshed whenever confirmed heap state is lost. LUMI initialisation calls `setUseDefaultKeyHandler(true, false)` (retain musical key handling, replace lighting).
 
-An unanswered challenge is retried without reuploading the program. The message callback can answer even if identical program bytes survive a reconnect without another initialisation callback. When confirmed heap state is lost, the daemon clears readiness, rotates the nonce, and restarts the code-only transfer while retaining the latest requested pixels. Replies from the previous transfer cannot release those pixels.
+An unanswered challenge is retried without reuploading the program. Both programs accept the challenge even if identical program bytes survive a reconnect without another initialisation callback. Lightpad acknowledges after a complete repaint; LUMI replies from the message callback. When confirmed heap state is lost, the daemon clears readiness, rotates the nonce, and restarts the code-only transfer while retaining the latest requested pixels. Replies from the previous transfer cannot release those pixels.
 
 An accepted API frame confirms daemon acceptance. The frame can remain queued during renderer startup. Neither API acceptance nor a device packet ACK establishes visible rendering.
 
 ## Programs and Pixel Layout
 
-| Surface               | Program size | Pixel heap        | Device coordinates          |
-| --------------------- | ------------ | ----------------- | --------------------------- |
-| Lightpad / Lightpad M | 145 bytes    | 450 bytes, RGB565 | 15×15 grid                  |
-| LUMI Keys             | 130 bytes    | 48 bytes, RGB565  | 24 keys at `(key_index, 0)` |
+| Surface               | Pixel heap                                  | Device coordinates          |
+| --------------------- | ------------------------------------------- | --------------------------- |
+| Lightpad / Lightpad M | Two 450-byte RGB565 banks (900 bytes total) | 15×15 grid                  |
+| LUMI Keys             | 48 bytes, RGB565                            | 24 keys at `(key_index, 0)` |
 
 Both programs expose `initialise()`, `repaint()`, and `handleMessage()`. Pixel data begins immediately after the program binary. Each little-endian 16-bit pixel stores red in bits 0 to 4, green in bits 5 to 10, and blue in bits 11 to 15. Repaint expands these channels to 8-bit values with shifts of 3, 2, and 3 bits respectively.
 
 LUMI does not expose the SDK's bitmap LEDGrid capability. Its key lighting uses `fillPixel(colour, key_index, 0)`, following the vendor's LittleFoot example. The separate key-frame API preserves that distinction.
+
+## Whole Lightpad Frames
+
+Lightpad keeps the visible image in one pixel bank while the host uploads into the other. Incoming API frames coalesce to the newest desired image independently of the frame being transferred.
+
+1. Upload a complete frame into the inactive bank and wait for its heap packets to be acknowledged.
+2. Send `(0x424C5000 | bank, session, sequence)` to request presentation.
+3. The renderer latches the bank at repaint entry and draws all 225 pixels from that bank.
+4. After the draw, it replies with `(0x424C4100 | bank, session, sequence)`. Only the matching reply releases the former bank for reuse.
+
+The readiness nonce identifies the session. A new readiness handshake establishes bank ownership even when identical program bytes survive without another initialisation callback. Retrying the same handshake does not reset ownership. Repeated presentation requests are idempotent; stale or wrong-bank acknowledgements cannot release a bank. A correlated `0x424C4E52` reply reports a lost renderer session and starts recovery.
+
+The presentation acknowledgement establishes completion of a logical repaint. It does not measure the physical LED scan or guarantee that every submitted API frame is displayed. Buffering adds one 450-byte bank without changing the API frame format or imposing a submission-rate limit.
 
 ## Program Binary Format
 
@@ -81,3 +94,9 @@ A minimal green test rendered visibly over the existing background. Disabling th
 Unknown heap bytes must differ from every target value, including zero. The diff engine maps unknown bytes to `target[i] ^ 0xFF` so the first transfer replaces stale memory.
 
 The USB-connected bridge must remain in API mode to forward messages to DNA-connected devices. The daemon activates and keeps alive every device in the topology.
+
+### Partial Animation Updates
+
+When new frames replaced the heap target during multipart uploads, each packet could start again at the newest changed prefix. A live rainbow sweep exposed the result: only the upper Lightpad rows moved. Completing an immutable transfer snapshot before selecting the newest target restores progress across the whole surface.
+
+Repainting directly from the receiving bank could still mix rows from different frames. The buffered renderer keeps the visible bank immutable until its successor has been fully uploaded and repainted.

--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -112,15 +112,15 @@ Built-in LED pattern generators: solid fill, horizontal/vertical gradient, rainb
 
 ### `opcodes.py`
 
-LittleFoot VM opcode definitions, register layout, and native function IDs. Based on the ROLI JUCE SDK source, with annotations for known firmware incompatibilities.
+LittleFoot VM opcode values and operand widths from the ROLI SDK. Renderer execution has been checked against the upstream VM; older illegal-instruction reports were reproduced as incorrect host-side jump addresses.
 
 ### `assembler.py`
 
-Bytecode assembler with label resolution and FNV1a function name hashing. Converts assembly-like instructions into valid LittleFoot program binaries including the program header, function table, and checksum.
+Bytecode assembler with program-relative label resolution and the SDK native signature hash. Converts assembly instructions into LittleFoot program binaries with a header, function table, and checksum.
 
 ### `programs.py`
 
-Pre-built LittleFoot programs. The primary one is BitmapLEDProgram: a 100-byte repaint routine that reads RGB565 pixel data from the heap and calls `fillPixel` for each pixel. Currently disabled due to firmware opcode incompatibility on v1.1.0.
+The 145-byte Lightpad renderer reads a 450-byte RGB565 heap and paints each grid pixel. The 130-byte LUMI renderer in `keys.py` reads a 48-byte heap and paints each key while preserving the default musical handler. Both initialise the display and answer host execution challenges before the host publishes pixel data.
 
 ## cli/
 

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -59,7 +59,7 @@ See the [Vision document](https://github.com/hyperb1iss/blocksd/blob/main/VISION
 
 ## Project Status
 
-blocksd is in alpha. Discovery and keepalive have prior hardware reports, but coverage varies by device and firmware. LittleFoot program upload is disabled because of firmware opcode incompatibilities. The unrolled fill program is also unreachable in the current daemon; accepted LED frames do not guarantee visible rendering. The hardware-independent test suite verifies software behavior, not device compatibility.
+blocksd is in alpha. Visible RGB patterns have been verified on Lightpad Block M firmware 1.1.0 and LUMI Keys firmware 1.3.9. Lighting loads a device-side renderer on the first frame. Hardware coverage varies by device and firmware; live MIDI/MPE preservation during LUMI lighting, sustained timing, and physical color calibration remain unverified. The hardware-independent test suite verifies software behavior, not device compatibility.
 
 | Phase                             | Status                |
 | --------------------------------- | --------------------- |

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -57,7 +57,7 @@ systemctl --user start blocksd
 
 The LED and config commands open their own MIDI sessions. Stop the service and any foreground daemon before using them. LED commands remain running until Ctrl+C; config commands probe for about eight seconds. Restart the service afterward.
 
-The current daemon does not upload its LittleFoot LED renderer (firmware opcode compatibility remains unresolved). LED commands and API frames can update heap data, but an accepted write does not establish visible LED output. See the [LittleFoot notes](../architecture/littlefoot).
+The first LED frame loads a LittleFoot renderer. Pixels follow complete upload acknowledgement and a matching reply to a fresh execution challenge. Visible RGB patterns have been verified on Lightpad M 1.1.0 and LUMI 1.3.9. API acceptance confirms daemon acceptance, not a visible display change. See the [LittleFoot notes](../architecture/littlefoot).
 
 If you have a Lightpad Block or Lightpad Block M, try the built-in LED patterns:
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -175,6 +175,8 @@ The `pixels` field is a base64-encoded 675-byte RGB888 payload. Use the binary p
 
 Write the 24 LUMI key colors in key-index order. The `pixels` field contains base64-encoded RGB888 data: exactly 72 bytes (red, green, blue for each key). The daemon applies the connection server's brightness setting and converts the data to the renderer's 48-byte RGB565 heap.
 
+The key renderer sets LUMI's hardware brightness to 100% when it starts and when it answers a readiness challenge after reconnecting. Clients control dimming through their RGB values or the API brightness setting. Gamma correction is unchanged.
+
 ```json
 { "type": "key_frame", "uid": 42, "pixels": "...base64..." }
 ```

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -38,8 +38,8 @@ WebSocket clients send JSON in text messages and the same 685-byte LED packet in
 
 1. Open a control socket
 2. Send `discover` to get the device list and `uid` values
-3. Only stream LED frames to devices with nonzero `grid_width` and `grid_height`
-4. Use the binary frame path (not JSON `frame`) for LED animation
+3. Use bitmap frames for nonzero grid dimensions; use JSON `key_frame` for `key_count = 24`
+4. Use the binary frame path for Lightpad animation; LUMI key frames use JSON
 5. Retry early frame rejections while the device is still coming up
 6. Open a second socket for `subscribe` if you also need events
 
@@ -75,7 +75,7 @@ Each parsed binary frame write returns one acknowledgement byte (inside a binary
 
 `0x00` means the device was unavailable, the `uid` was unknown, or the payload was invalid. Early rejections during device startup are retryable.
 
-Acceptance confirms a daemon-side heap update, not a hardware acknowledgement or visible display change. LittleFoot renderer upload is currently disabled; see the [firmware limitation](../architecture/littlefoot).
+Acceptance confirms that the daemon accepted the frame, not a hardware acknowledgement or visible display change. The first frame triggers renderer upload and can remain queued until the code transfer is acknowledged and the renderer answers a fresh execution challenge. See [renderer startup](../architecture/littlefoot).
 
 ### Python Example
 
@@ -139,6 +139,7 @@ List all connected devices with capabilities and battery status.
       "name": "",
       "grid_width": 15,
       "grid_height": 15,
+      "key_count": 0,
       "battery_level": 31,
       "battery_charging": false,
       "firmware_version": null
@@ -150,10 +151,10 @@ List all connected devices with capabilities and battery status.
 
 The `uid` is a deterministic 64-bit identifier derived from the device serial. Clients can cache it across daemon restarts.
 
-Devices with `grid_width = 0` and `grid_height = 0` do not expose an LED frame surface. Only Lightpad Block and Lightpad Block M advertise non-zero grid dimensions.
+Only Lightpad Block and Lightpad Block M advertise nonzero grid dimensions and accept bitmap frames. LUMI advertises `grid_width = 0`, `grid_height = 0`, and `key_count = 24`; use `key_frame` for its key colors. Other recognized devices report `key_count = 0`.
 
 ::: warning
-Discovery is topology-driven, not readiness-driven. A device can appear in `discover_response` before the daemon has finished API mode activation and heap setup. Keep writing frames only after you get an accepted ack.
+A device can appear in `discover_response` before API mode activation and heap setup finish. Retry rejected writes after discovery settles. An accepted frame can still be waiting for renderer initialisation; acceptance does not expose renderer readiness.
 :::
 
 ### `frame`
@@ -169,6 +170,22 @@ JSON-based LED frame write. Supported for compatibility and debugging, but not r
 ```
 
 The `pixels` field is a base64-encoded 675-byte RGB888 payload. Use the binary protocol for high-rate updates.
+
+### `key_frame`
+
+Write the 24 LUMI key colors in key-index order. The `pixels` field contains base64-encoded RGB888 data: exactly 72 bytes (red, green, blue for each key). The daemon applies the connection server's brightness setting and converts the data to the renderer's 48-byte RGB565 heap.
+
+```json
+{ "type": "key_frame", "uid": 42, "pixels": "...base64..." }
+```
+
+```json
+{ "type": "key_frame_ack", "uid": 42, "accepted": true }
+```
+
+Key frames require a LUMI device with a reported firmware version of 1.3.0 or newer. Invalid base64, incorrect length, an unsupported device, or an unavailable/older firmware version produces `accepted: false`. The existing 685-byte binary frame format remains dedicated to 15×15 Lightpad grids.
+
+For example, construct a red frame in Python with `base64.b64encode(bytes([255, 0, 0]) * 24).decode("ascii")`.
 
 ### `brightness`
 
@@ -295,7 +312,8 @@ Frame writes are rejected when:
 
 - The `uid` does not exist
 - The payload size is wrong
-- The device has not finished entering API/heap-ready state
-- The block does not expose LED heap control
+- The device has not finished entering API mode or has no heap
+- The device does not support the requested bitmap or key surface
+- A key frame targets unsupported or unavailable LUMI firmware
 
 When in doubt: retry discovery, retry frame writes until accepted, and assume a reconnect invalidates any cached readiness state.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -59,7 +59,7 @@ The quick scan lists MIDI ports matching ROLI's naming convention. The `--probe`
 
 ## `blocksd led`
 
-Control the 15x15 LED grid on Lightpad Block and Lightpad Block M. These commands start their own MIDI discovery and keepalive session, apply the pattern as devices connect, and remain running until Ctrl+C. Stop any existing daemon first. Program upload is disabled, so heap writes do not guarantee visible LED output (see [LittleFoot](../architecture/littlefoot)).
+Control Lightpad grids and LUMI key colors. These commands start their own MIDI discovery and keepalive session, apply the pattern as devices connect, and remain running until Ctrl+C. Stop any existing daemon first and restart it afterward. The first frame loads a LittleFoot renderer; pixel delivery waits for upload acknowledgement and a matching execution challenge reply (see [LittleFoot](../architecture/littlefoot)).
 
 ### `blocksd led solid`
 
@@ -100,10 +100,21 @@ blocksd led checkerboard ff0000 00ff00 --size 5    # 5x5 squares
 
 ### `blocksd led off`
 
-Turn off all LEDs (fill with black).
+Turn off the Lightpad grid (fill with black).
 
 ```bash
 blocksd led off
+```
+
+### `blocksd led keys`
+
+Set all 24 LUMI key colors to a rainbow or a single hex color. Requires LUMI firmware 1.3.0 or newer; visible rendering has been verified on 1.3.9. The renderer retains the default musical key handler. Live MIDI/MPE preservation during lighting still needs a dedicated acceptance check.
+
+```bash
+blocksd led keys
+blocksd led keys rainbow
+blocksd led keys '#ff00ff'
+blocksd led keys 000000              # key lights off
 ```
 
 ## `blocksd config`

--- a/docs/reference/devices.md
+++ b/docs/reference/devices.md
@@ -1,6 +1,6 @@
 # Supported Devices
 
-ROLI shipped a surprisingly diverse family of Blocks devices: pressure-sensitive pads, keyboard strips, control surfaces, loop controllers, and more. blocksd identifies known Blocks serial prefixes and manages discovered devices through the topology and keepalive protocol. Compatibility must be checked per device and firmware. LED bitmap streaming is currently limited to the Lightpad family, which is the only device type with an addressable RGB grid.
+ROLI shipped a surprisingly diverse family of Blocks devices: pressure-sensitive pads, keyboard strips, control surfaces, loop controllers, and more. blocksd identifies known Blocks serial prefixes and manages discovered devices through the topology and keepalive protocol. Compatibility must be checked per device and firmware. Lightpad devices expose a bitmap grid; LUMI Keys uses a separate per-key lighting surface.
 
 ## Device Matrix
 
@@ -21,21 +21,20 @@ ROLI shipped a surprisingly diverse family of Blocks devices: pressure-sensitive
 
 ## What "Tested" Means
 
-**Tested** records prior project hardware reports, not a release-by-release certification. A passing software test suite does not establish physical device compatibility or visible LED rendering.
+**Tested** records prior project hardware reports, not a release-by-release certification. Visible RGB patterns were confirmed on Lightpad Block M firmware 1.1.0 and LUMI Keys firmware 1.3.9 on September 7, 2026. The original Lightpad has no new rendering validation from that session. Live MIDI/MPE preservation during LUMI lighting, sustained frame timing, and physical color calibration remain unverified.
 
 **Untested** means no hardware validation is recorded here. A USB PID or serial prefix in the source does not guarantee discovery or support. Non-Blocks products in the table are identification references only; the MIDI scanner requires a matching Blocks port name.
 
 ## LED Capabilities
 
-The daemon currently skips LittleFoot program upload. An accepted frame is a heap write, not proof of visible rendering (see [LittleFoot status](../architecture/littlefoot)).
+The first frame loads the appropriate LittleFoot renderer. Pixel delivery waits for complete upload acknowledgement and a matching renderer challenge reply. Accepted API frames confirm daemon acceptance, not visible output (see [LittleFoot status](../architecture/littlefoot)).
 
-Only Lightpad Block and Lightpad Block M expose a 15x15 RGB LED grid through the bitmap frame protocol. These are the only devices that:
+| Device                | Discovery capability                                   | Frame API                     | CLI                                                       |
+| --------------------- | ------------------------------------------------------ | ----------------------------- | --------------------------------------------------------- |
+| Lightpad / Lightpad M | `grid_width = 15`, `grid_height = 15`, `key_count = 0` | Binary bitmap or JSON `frame` | `led solid`, `rainbow`, `gradient`, `checkerboard`, `off` |
+| LUMI Keys             | `grid_width = 0`, `grid_height = 0`, `key_count = 24`  | JSON `key_frame`              | `led keys`                                                |
 
-- Advertise `grid_width = 15` and `grid_height = 15` in discovery
-- Accept binary LED frame writes
-- Respond to `blocksd led` CLI commands
-
-Other recognized Blocks devices can participate in discovery and keepalive, but they advertise `grid_width = 0` / `grid_height = 0` and reject frame writes.
+Key lighting requires LUMI firmware 1.3.0 or newer. Other recognized Blocks can participate in discovery and keepalive, but do not expose a supported lighting surface.
 
 ## Touch and Button Events
 
@@ -61,7 +60,7 @@ Devices have limited memory for LittleFoot programs:
 | Pad Block (Lightpad) | 7200 bytes     | 800 bytes |
 | Control Block        | 3000 bytes     | 800 bytes |
 
-The BitmapLEDProgram (LED repaint routine) is 100 bytes, leaving the rest of the heap available for pixel data.
+The Lightpad renderer occupies 145 bytes plus a 450-byte pixel heap. The LUMI renderer occupies 130 bytes plus a 48-byte pixel heap.
 
 ## USB Identification
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -71,6 +71,12 @@ ls -la /tmp/blocksd/blocksd.sock
 ls -la $XDG_RUNTIME_DIR/blocksd/blocksd.sock
 ```
 
+## Only Part of the Lightpad Animates
+
+A stripe or moving upper rows with a frozen lower section can indicate an older heap streamer that repeatedly replaces an unfinished frame. Update to a build that completes transfer snapshots. If every row moves but the lower rows lag, use the buffered Lightpad renderer described in [Whole Lightpad Frames](./architecture/littlefoot#whole-lightpad-frames).
+
+API acceptance measures queuing, so successful frame replies alone do not rule out either problem. A static corner pattern can help distinguish orientation or mapping errors from partial animation updates.
+
 ## High CPU Usage
 
 **Symptom**: blocksd using more CPU than expected.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -57,11 +57,11 @@ Common causes:
 
 **Symptom**: `blocksd led solid '#ff00ff'` returns but the Lightpad doesn't change.
 
-**Check the renderer limitation first.** The daemon currently skips LittleFoot program upload. Heap writes may be accepted without changing the display. See [LittleFoot status](./architecture/littlefoot).
+**Check renderer startup.** The first frame uploads a renderer, then waits for complete code acknowledgement and a matching execution challenge reply before sending pixels. An accepted API frame can still be queued during startup. Check verbose logs for renderer initialisation or device errors, and see [LittleFoot status](./architecture/littlefoot) for tested firmware.
 
 The LED CLI opens its own MIDI session and stays running until Ctrl+C. Stop the service before using it; API clients should instead connect to the running daemon.
 
-**Is it a Lightpad?** Only Lightpad Block and Lightpad Block M support LED bitmap control. The current bitmap API does not expose a grid for devices such as LUMI Keys.
+**Use the matching lighting surface.** Lightpad Block and Lightpad Block M accept bitmap frames. LUMI Keys uses `blocksd led keys` or JSON `key_frame` and requires firmware 1.3.0 or newer.
 
 **Check the socket**:
 

--- a/src/blocksd/api/commands.py
+++ b/src/blocksd/api/commands.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 from blocksd import __version__
 from blocksd.api.events import VALID_EVENTS, EventBroadcaster, _connection_to_dict, _device_to_dict
 from blocksd.api.protocol import PIXEL_DATA_SIZE, decode_json, parse_binary_frame
+from blocksd.device.registry import key_count_for_block, supports_key_led_program
 from blocksd.led.bitmap import Color, LEDGrid
 
 if TYPE_CHECKING:
@@ -85,6 +86,9 @@ class ApiCommands:
         if msg_type == "frame":
             return self._handle_json_frame(msg), None
 
+        if msg_type == "key_frame":
+            return self._handle_json_frame(msg, key_frame=True), None
+
         if msg_type == "brightness":
             return self._handle_brightness(msg), None
 
@@ -128,19 +132,21 @@ class ApiCommands:
             resp["id"] = msg_id
         return resp
 
-    def _handle_json_frame(self, msg: dict[str, Any]) -> dict[str, Any]:
+    def _handle_json_frame(self, msg: dict[str, Any], *, key_frame: bool = False) -> dict[str, Any]:
         uid = msg.get("uid")
         pixels_b64 = msg.get("pixels", "")
+        ack_type = "key_frame_ack" if key_frame else "frame_ack"
         if type(uid) is not int:
-            return {"type": "frame_ack", "uid": uid if uid is not None else 0, "accepted": False}
+            return {"type": ack_type, "uid": uid if uid is not None else 0, "accepted": False}
 
         try:
             pixels = base64.b64decode(pixels_b64, validate=True)
         except (binascii.Error, TypeError, ValueError):
-            return {"type": "frame_ack", "uid": uid, "accepted": False}
+            return {"type": ack_type, "uid": uid, "accepted": False}
 
-        accepted = self._write_rgb888_frame(uid, pixels)
-        return {"type": "frame_ack", "uid": uid, "accepted": accepted}
+        writer = self._write_rgb888_key_frame if key_frame else self._write_rgb888_frame
+        accepted = writer(uid, pixels)
+        return {"type": ack_type, "uid": uid, "accepted": accepted}
 
     def _handle_brightness(self, msg: dict[str, Any]) -> dict[str, Any]:
         uid = msg.get("uid")
@@ -169,10 +175,26 @@ class ApiCommands:
         if device is None:
             return False
 
-        brightness = self._brightness_map.get(uid, 255)
-        grid = LEDGrid()
+        grid = self._rgb888_grid(uid, pixels, cols=15, rows=15)
+        return self._manager.set_led_data(uid, grid.heap_data)
 
-        for i in range(225):
+    def _write_rgb888_key_frame(self, uid: int, pixels: bytes) -> bool:
+        """Write one RGB888 color per physical key on a supported keyboard."""
+        device = self._manager.find_device(uid)
+        if device is None or not supports_key_led_program(device.block_type):
+            return False
+
+        key_count = key_count_for_block(device.block_type)
+        if len(pixels) != key_count * 3:
+            return False
+
+        grid = self._rgb888_grid(uid, pixels, cols=key_count, rows=1)
+        return self._manager.set_key_led_data(uid, grid.heap_data)
+
+    def _rgb888_grid(self, uid: int, pixels: bytes, *, cols: int, rows: int) -> LEDGrid:
+        brightness = self._brightness_map.get(uid, 255)
+        grid = LEDGrid(cols=cols, rows=rows)
+        for i in range(cols * rows):
             offset = i * 3
             r, g, b = pixels[offset], pixels[offset + 1], pixels[offset + 2]
 
@@ -182,11 +204,10 @@ class ApiCommands:
                 g = (g * brightness) // 255
                 b = (b * brightness) // 255
 
-            x = i % 15
-            y = i // 15
+            x = i % cols
+            y = i // cols
             grid.set_pixel(x, y, Color(r, g, b))
-
-        return self._manager.set_led_data(uid, grid.heap_data)
+        return grid
 
     def _handle_config_get(self, msg: dict[str, Any]) -> dict[str, Any]:
         uid = msg.get("uid")

--- a/src/blocksd/api/events.py
+++ b/src/blocksd/api/events.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
-from blocksd.device.registry import bitmap_grid_dimensions
+from blocksd.device.registry import bitmap_grid_dimensions, key_count_for_block
 
 if TYPE_CHECKING:
     from blocksd.device.models import (
@@ -151,6 +151,7 @@ def _device_to_dict(dev: DeviceInfo) -> dict[str, Any]:
         "battery_charging": dev.battery_charging,
         "grid_width": grid_width,
         "grid_height": grid_height,
+        "key_count": key_count_for_block(dev.block_type),
         "firmware_version": dev.version or None,
     }
 

--- a/src/blocksd/cli/led.py
+++ b/src/blocksd/cli/led.py
@@ -11,6 +11,11 @@ from typing import TYPE_CHECKING
 import typer
 
 from blocksd.cli.app import app
+from blocksd.device.registry import (
+    bitmap_grid_dimensions,
+    key_count_for_block,
+    supports_key_led_program,
+)
 from blocksd.led.bitmap import Color, LEDGrid
 
 if TYPE_CHECKING:
@@ -30,6 +35,8 @@ log = logging.getLogger(__name__)
 def _run_with_pattern(
     pattern_fn: Callable[[LEDGrid], None],
     verbose: bool = False,
+    *,
+    key_lighting: bool = False,
 ) -> None:
     """Start a mini-daemon, apply a pattern to each device as it connects."""
     from blocksd.logging import setup_logging
@@ -38,14 +45,45 @@ def _run_with_pattern(
     setup_logging(verbose=verbose)
 
     manager = TopologyManager()
+    pending_keys: dict[int, DeviceInfo] = {}
 
     def on_device(dev: DeviceInfo) -> None:
-        grid = LEDGrid()
+        if key_lighting:
+            if not supports_key_led_program(dev.block_type):
+                return
+            if not dev.version:
+                pending_keys[dev.uid] = dev
+                return
+            pending_keys.pop(dev.uid, None)
+            cols, rows = key_count_for_block(dev.block_type), 1
+            write_frame = manager.set_key_led_data
+        else:
+            cols, rows = bitmap_grid_dimensions(dev.block_type)
+            if not cols or not rows:
+                return
+            write_frame = manager.set_led_data
+        grid = LEDGrid(cols=cols, rows=rows)
         pattern_fn(grid)
-        if manager.set_led_data(dev.uid, grid.heap_data):
+        if write_frame(dev.uid, grid.heap_data):
             log.info("Applied LED pattern to %s (%s)", dev.block_type, dev.serial)
+        elif key_lighting:
+            log.warning("Key lighting rejected for %s (firmware %s)", dev.serial, dev.version)
 
     manager.on_device_added.append(on_device)
+
+    def on_removed(dev: DeviceInfo) -> None:
+        pending_keys.pop(dev.uid, None)
+
+    if key_lighting:
+        manager.on_device_removed.append(on_removed)
+
+    async def deliver_pending_keys() -> None:
+        # Firmware arrives separately from discovery without a readiness event.
+        while True:
+            for dev in list(pending_keys.values()):
+                if dev.version:
+                    on_device(dev)
+            await asyncio.sleep(0.05)
 
     async def run() -> None:
         loop = asyncio.get_running_loop()
@@ -54,16 +92,46 @@ def _run_with_pattern(
             loop.add_signal_handler(sig, stop.set)
 
         task = asyncio.create_task(manager.run(), name="led-manager")
+        pending_task = (
+            asyncio.create_task(deliver_pending_keys(), name="led-key-readiness")
+            if key_lighting
+            else None
+        )
         typer.echo("Scanning for ROLI devices... (Ctrl+C to stop)")
-        await stop.wait()
-        task.cancel()
-        with contextlib.suppress(asyncio.CancelledError):
-            await task
+        try:
+            await stop.wait()
+        finally:
+            task.cancel()
+            if pending_task is not None:
+                pending_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+            if pending_task is not None:
+                with contextlib.suppress(asyncio.CancelledError):
+                    await pending_task
 
     asyncio.run(run())
 
 
 # ── Commands ─────────────────────────────────────────────────────────────────
+
+
+@led_app.command()
+def keys(
+    color: str = typer.Argument("rainbow", help="Hex color or 'rainbow' for all 24 LUMI keys"),
+    verbose: bool = typer.Option(False, "--verbose", "-v"),
+) -> None:
+    """Light LUMI keys with a color or rainbow. Stop the daemon before running.
+
+    Keep this command running to maintain the lights; press Ctrl+C to stop.
+    """
+    from blocksd.led.patterns import rainbow as rainbow_pattern
+
+    if color.lower() == "rainbow":
+        _run_with_pattern(rainbow_pattern, verbose=verbose, key_lighting=True)
+    else:
+        parsed = _parse_color(color)
+        _run_with_pattern(lambda grid: grid.fill(parsed), verbose=verbose, key_lighting=True)
 
 
 @led_app.command()

--- a/src/blocksd/device/registry.py
+++ b/src/blocksd/device/registry.py
@@ -65,3 +65,12 @@ def bitmap_grid_dimensions(block_type: BlockType) -> tuple[int, int]:
 def supports_bitmap_led_program(block_type: BlockType) -> bool:
     """Whether the device exposes an upstream LEDGrid-style bitmap surface."""
     return bitmap_grid_dimensions(block_type) != (0, 0)
+
+
+def key_count_for_block(block_type: BlockType) -> int:
+    """Return the number of independently illuminated LUMI keys."""
+    return 24 if block_type == BlockType.LUMI_KEYS else 0
+
+
+def supports_key_led_program(block_type: BlockType) -> bool:
+    return key_count_for_block(block_type) > 0

--- a/src/blocksd/led/buffered_program.py
+++ b/src/blocksd/led/buffered_program.py
@@ -1,0 +1,91 @@
+"""Present complete bitmap frames while retaining an immutable visible bank."""
+
+from __future__ import annotations
+
+import time
+
+from blocksd.led.program import LEDProgram
+from blocksd.littlefoot.bitmap_lifecycle import NOT_READY, PRESENT_BASE, PRESENTED_BASE
+from blocksd.littlefoot.lifecycle import RENDERER_READY_MARKER
+
+_PRESENT_RETRY_INTERVAL = 0.250
+_MAX_SEQUENCE = 0x7FFFFFFF
+
+
+class BufferedLEDProgram(LEDProgram):
+    """Upload the inactive bank and release the previous bank after its repaint.
+
+    Incoming frames coalesce independently of the submitted frame. Readiness
+    establishes bank zero for each new session, including unchanged bytecode
+    whose initialise callback does not run again.
+    """
+
+    def _prepare_upload(self) -> None:
+        super()._prepare_upload()
+        self._active_bank = 0
+        self._visible = bytes(self.frame_size)
+        self._submitted: bytes | None = None
+        self._sequence = 0
+        self._last_present: float | None = None
+
+    def set_frame(self, pixels: bytes | bytearray) -> bool:
+        self._sync_generation()
+        if len(pixels) != self.frame_size:
+            return False
+        self._pixels = bytes(pixels)
+        self._queue_frame()
+        return True
+
+    def _queue_frame(self) -> None:
+        if not self.ready or self._submitted is not None or self._pixels == self._visible:
+            return
+        if self._sequence == _MAX_SEQUENCE:
+            self.heap.reset_device_state()
+            self._sync_generation()
+            return
+        self._sequence += 1
+        self._submitted = self._pixels
+        self._last_present = None
+        offset = len(self.code) + (1 - self._active_bank) * self.frame_size
+        self.heap.set_bytes(offset, self._submitted)
+
+    def on_ready(self, message: tuple[int, int, int]) -> None:
+        self._sync_generation()
+        if not self.ready:
+            if (
+                self._last_query is not None
+                and message == (RENDERER_READY_MARKER, self.kind, self._nonce)
+                and not self.heap.is_dirty
+                and self.heap.in_flight_count == 0
+            ):
+                self.ready = True
+                self._queue_frame()
+            return
+        if self._submitted is None or self._last_present is None:
+            return
+        if message == (NOT_READY, self._nonce, self._sequence):
+            self.heap.reset_device_state()
+            self._sync_generation()
+            return
+        bank = 1 - self._active_bank
+        if message != (PRESENTED_BASE | bank, self._nonce, self._sequence):
+            return
+        self._active_bank = bank
+        self._visible = self._submitted
+        self._submitted = None
+        self._last_present = None
+        self._queue_frame()
+
+    def advance(self, now: float | None = None) -> tuple[int, int, int] | None:
+        self._sync_generation()
+        if not self.ready:
+            return super().advance(now)
+        self._queue_frame()
+        if self._submitted is None or self.heap.is_dirty or self.heap.in_flight_count:
+            return None
+        if now is None:
+            now = time.monotonic()
+        if self._last_present is not None and now - self._last_present < _PRESENT_RETRY_INTERVAL:
+            return None
+        self._last_present = now
+        return (PRESENT_BASE | (1 - self._active_bank), self._nonce, self._sequence)

--- a/src/blocksd/led/program.py
+++ b/src/blocksd/led/program.py
@@ -1,0 +1,86 @@
+"""Sequence renderer execution challenges before publishing pixel frames."""
+
+from __future__ import annotations
+
+import secrets
+import time
+from typing import TYPE_CHECKING
+
+from blocksd.littlefoot.lifecycle import RENDERER_READY_MARKER
+
+if TYPE_CHECKING:
+    from blocksd.protocol.remote_heap import RemoteHeap
+
+_QUERY_RETRY_INTERVAL = 0.250
+_MAX_NONCE = 0x7FFFFFFF
+
+
+class LEDProgram:
+    """Keep pixels separate until the uploaded renderer answers a fresh challenge.
+
+    Firmware can clear pixels during initialisation. Heap state loss therefore
+    restarts the code-only transfer and invalidates every earlier ready reply.
+    """
+
+    def __init__(self, heap: RemoteHeap, code: bytes, kind: int, frame_size: int) -> None:
+        self.heap = heap
+        self.code = code
+        self.kind = kind
+        self.frame_size = frame_size
+        self.ready = False
+        self._pixels = bytes(frame_size)
+        self._generation = heap.generation
+        self._nonce = secrets.randbelow(_MAX_NONCE) + 1
+        self._last_query: float | None = None
+        self._prepare_upload()
+
+    def _prepare_upload(self) -> None:
+        self.heap.set_bytes(0, bytes(self.heap.size))
+        self.heap.set_bytes(0, self.code)
+
+    def _sync_generation(self) -> None:
+        if self._generation != self.heap.generation:
+            self._generation = self.heap.generation
+            self.ready = False
+            self._last_query = None
+            self._nonce = self._nonce % _MAX_NONCE + 1
+            self._prepare_upload()
+
+    def set_frame(self, pixels: bytes | bytearray) -> bool:
+        """Accept a complete frame, retaining only the latest during startup."""
+        self._sync_generation()
+        if len(pixels) != self.frame_size:
+            return False
+        self._pixels = bytes(pixels)
+        if self.ready:
+            self.heap.set_bytes(len(self.code), self._pixels)
+        return True
+
+    def on_ready(self, message: tuple[int, int, int]) -> None:
+        """Publish pixels only for a reply to the current generation's challenge."""
+        self._sync_generation()
+        if (
+            not self.ready
+            and self._last_query is not None
+            and message == (RENDERER_READY_MARKER, self.kind, self._nonce)
+            and not self.heap.is_dirty
+            and self.heap.in_flight_count == 0
+        ):
+            self.ready = True
+            self.heap.set_bytes(len(self.code), self._pixels)
+
+    def advance(self, now: float | None = None) -> tuple[int, int, int] | None:
+        """Return a readiness challenge after the entire code transfer is ACKed.
+
+        Only an unanswered challenge is retried. Live pixel delivery has no
+        query cadence, and unchanged programs can answer after reconnecting.
+        """
+        self._sync_generation()
+        if self.ready or self.heap.is_dirty or self.heap.in_flight_count:
+            return None
+        if now is None:
+            now = time.monotonic()
+        if self._last_query is not None and now - self._last_query < _QUERY_RETRY_INTERVAL:
+            return None
+        self._last_query = now
+        return (RENDERER_READY_MARKER, self.kind, self._nonce)

--- a/src/blocksd/littlefoot/assembler.py
+++ b/src/blocksd/littlefoot/assembler.py
@@ -252,10 +252,9 @@ class BytecodeAssembler:
 
     def build(self) -> bytes:
         """Assemble the final program binary with header, function table, and bytecode."""
-        self._resolve_labels()
-
         func_table_size = len(self._functions) * _FUNC_ENTRY_SIZE
         code_base = _HEADER_SIZE + func_table_size
+        self._resolve_labels(code_base)
 
         # Build function table
         func_table = bytearray()
@@ -291,10 +290,10 @@ class BytecodeAssembler:
     def _emit_i32(self, value: int) -> None:
         self._code.extend(struct.pack("<i", value))
 
-    def _resolve_labels(self) -> None:
-        """Patch all label references with actual code offsets."""
+    def _resolve_labels(self, code_base: int) -> None:
+        """Patch labels with addresses relative to the complete program binary."""
         for fixup in self._fixups:
             if fixup.label not in self._labels:
                 raise ValueError(f"Undefined label: {fixup.label!r}")
-            target = self._labels[fixup.label]
+            target = code_base + self._labels[fixup.label]
             struct.pack_into("<h", self._code, fixup.code_offset, target)

--- a/src/blocksd/littlefoot/assembler.py
+++ b/src/blocksd/littlefoot/assembler.py
@@ -188,9 +188,7 @@ class BytecodeAssembler:
         self._emit_byte(Op.DUP)
 
     def dup_offset(self, offset: int) -> None:
-        # Always use the general form with explicit int8 operand.
-        # Firmware v1.1.0 doesn't have the fast-path dupOffset_01-07
-        # opcodes — position 0x12 is the general dupOffset(int8).
+        # Encode stack indices explicitly with the general duplication form.
         if offset <= 0xFF:
             self._emit_byte(Op.DUP_OFFSET)
             self._emit_byte(offset & 0xFF)

--- a/src/blocksd/littlefoot/bitmap_lifecycle.py
+++ b/src/blocksd/littlefoot/bitmap_lifecycle.py
@@ -1,0 +1,170 @@
+"""Bank ownership and presentation messages for the bitmap renderer."""
+
+from __future__ import annotations
+
+from blocksd.littlefoot.assembler import BytecodeAssembler, compute_function_id
+from blocksd.littlefoot.lifecycle import BITMAP_RENDERER, RENDERER_READY_MARKER
+
+BITMAP_FRAME_BYTES = 450
+PRESENT_BASE = 0x424C5000
+PRESENTED_BASE = 0x424C4100
+NOT_READY = 0x424C4E52
+BITMAP_GLOBALS = 6
+
+_SESSION = 0
+_ACTIVE_BANK = 1
+_PENDING_BANK = 2
+_PENDING_SEQUENCE = 3
+_PRESENTED_SEQUENCE = 4
+_READY_PENDING = 5
+_SEND_MESSAGE = compute_function_id("sendMessageToHost/viii")
+
+
+def emit_bitmap_repaint_begin(asm: BytecodeAssembler) -> None:
+    """Latch session, readiness, bank, and presentation identity for this draw."""
+    asm.dup_from_global(_SESSION)
+    asm.dup_from_global(_READY_PENDING)
+    asm.push0()
+    asm.drop_to_global(_READY_PENDING)
+    asm.dup_from_global(_PENDING_SEQUENCE)
+    asm.jump_if_false("no_pending_bank")
+    asm.dup_from_global(_PENDING_BANK)
+    asm.drop_to_global(_ACTIVE_BANK)
+    asm.dup_from_global(_PENDING_SEQUENCE)
+    asm.drop_to_global(_PRESENTED_SEQUENCE)
+    asm.label("no_pending_bank")
+    asm.dup_from_global(_ACTIVE_BANK)
+    asm.dup_from_global(_PENDING_SEQUENCE)
+    asm.push0()
+    asm.drop_to_global(_PENDING_SEQUENCE)
+    # Stack: session, readiness, bank, sequence, bit base.
+    asm.dup_offset(1)
+    asm.push16(BITMAP_FRAME_BYTES * 8)
+    asm.mul_int32()
+
+
+def emit_bitmap_repaint_end(asm: BytecodeAssembler) -> None:
+    """Acknowledge only after the complete draw, using its latched identity."""
+    asm.drop()  # Bit base.
+    asm.dup_offset(3)
+    asm.dup_from_global(_SESSION)
+    asm.sub_int32()
+    asm.jump_if_true("draw_ack_done")
+    asm.dup_offset(2)
+    asm.jump_if_false("draw_present_ack")
+    asm.dup_offset(3)
+    asm.push_int(BITMAP_RENDERER)
+    asm.push32(RENDERER_READY_MARKER)
+    asm.call_native(_SEND_MESSAGE)
+    asm.label("draw_present_ack")
+    asm.dup()
+    asm.jump_if_false("draw_ack_done")
+    asm.dup()
+    asm.dup_offset(4)
+    asm.dup_offset(3)
+    asm.push32(PRESENTED_BASE)
+    asm.add_int32()
+    asm.call_native(_SEND_MESSAGE)
+    asm.label("draw_ack_done")
+    for _ in range(4):
+        asm.drop()
+
+
+def emit_bitmap_message_handler(asm: BytecodeAssembler) -> None:
+    """Process ordered session changes and idempotent bank presentations.
+
+    READY establishes a new session on the ordered MIDI stream. Retrying the
+    current session never resets bank ownership. PRESENT identifies its session,
+    sequence, and bank independently, so delayed presentation retries are inert.
+    """
+    asm.begin_function("handleMessage/viii")
+    asm.dup_offset(1)
+    asm.push32(RENDERER_READY_MARKER)
+    asm.sub_int32()
+    asm.jump_if_true("check_present_markers")
+    asm.dup_offset(2)
+    asm.push_int(BITMAP_RENDERER)
+    asm.sub_int32()
+    asm.jump_if_true("ignore_bitmap_message")
+    asm.dup_offset(3)
+    asm.push1()
+    asm.sub_int32()
+    asm.test_ge_int32()
+    asm.jump_if_false("ignore_bitmap_message")
+    asm.dup_offset(3)
+    asm.dup_from_global(_SESSION)
+    asm.sub_int32()
+    asm.jump_if_false("ready_session_set")
+    asm.dup_offset(3)
+    asm.drop_to_global(_SESSION)
+    for index in (_ACTIVE_BANK, _PENDING_BANK, _PENDING_SEQUENCE, _PRESENTED_SEQUENCE):
+        asm.push0()
+        asm.drop_to_global(index)
+    asm.label("ready_session_set")
+    asm.push1()
+    asm.drop_to_global(_READY_PENDING)
+    asm.ret_void(3)
+
+    asm.label("check_present_markers")
+    for bank in (0, 1):
+        asm.dup_offset(1)
+        asm.push32(PRESENT_BASE | bank)
+        asm.sub_int32()
+        asm.jump_if_false(f"present_bank_{bank}")
+    asm.jump("ignore_bitmap_message")
+    for bank in (0, 1):
+        _emit_present_bank(asm, bank)
+    asm.label("wrong_session")
+    asm.dup_offset(3)
+    asm.dup_offset(3)
+    asm.push32(NOT_READY)
+    asm.call_native(_SEND_MESSAGE)
+    asm.label("ignore_bitmap_message")
+    asm.ret_void(3)
+
+
+def _emit_present_bank(asm: BytecodeAssembler, bank: int) -> None:
+    asm.label(f"present_bank_{bank}")
+    asm.dup_offset(2)
+    asm.dup_from_global(_SESSION)
+    asm.sub_int32()
+    asm.jump_if_true("wrong_session")
+    asm.dup_offset(3)
+    asm.push1()
+    asm.sub_int32()
+    asm.test_ge_int32()
+    asm.jump_if_false("ignore_bitmap_message")
+    asm.dup_offset(3)
+    asm.dup_from_global(_PRESENTED_SEQUENCE)
+    asm.sub_int32()
+    asm.jump_if_false(f"repeat_bank_{bank}")
+    asm.dup_offset(3)
+    asm.dup_from_global(_PRESENTED_SEQUENCE)
+    asm.sub_int32()
+    asm.push1()
+    asm.sub_int32()
+    asm.jump_if_true("ignore_bitmap_message")
+    # A new sequence may only select the inactive bank.
+    asm.dup_from_global(_ACTIVE_BANK)
+    asm.push_int(bank)
+    asm.sub_int32()
+    asm.jump_if_false("ignore_bitmap_message")
+    asm.jump(f"queue_bank_{bank}")
+    asm.label(f"repeat_bank_{bank}")
+    asm.dup_from_global(_ACTIVE_BANK)
+    asm.push_int(bank)
+    asm.sub_int32()
+    asm.jump_if_true("ignore_bitmap_message")
+    asm.label(f"queue_bank_{bank}")
+    asm.dup_from_global(_PENDING_SEQUENCE)
+    asm.jump_if_false(f"store_bank_{bank}")
+    asm.dup_from_global(_PENDING_SEQUENCE)
+    asm.dup_offset(4)
+    asm.sub_int32()
+    asm.jump_if_true("ignore_bitmap_message")
+    asm.label(f"store_bank_{bank}")
+    asm.push_int(bank)
+    asm.drop_to_global(_PENDING_BANK)
+    asm.dup_offset(3)
+    asm.drop_to_global(_PENDING_SEQUENCE)
+    asm.ret_void(3)

--- a/src/blocksd/littlefoot/keys.py
+++ b/src/blocksd/littlefoot/keys.py
@@ -1,0 +1,76 @@
+"""LUMI key lighting with the firmware's musical key handling preserved."""
+
+from __future__ import annotations
+
+from functools import lru_cache
+
+from blocksd.littlefoot.assembler import BytecodeAssembler, compute_function_id
+from blocksd.littlefoot.lifecycle import KEY_RENDERER, emit_renderer_query_handler
+
+KEY_COUNT = 24
+KEY_HEAP_SIZE = KEY_COUNT * 2
+
+
+@lru_cache(maxsize=1)
+def key_led_program() -> bytes:
+    """Build a 24-key RGB565 renderer for LUMI firmware 1.3.0 or newer.
+
+    The 48-byte heap uses the same little-endian RGB565 layout as LEDGrid,
+    in key-index order. Initialise keeps the default touch/MIDI handler and
+    replaces only key lighting. Repaint calls fillPixel(colour, key, 0).
+    """
+    asm = BytecodeAssembler(heap_size=KEY_HEAP_SIZE)
+    asm.begin_function("initialise/v")
+    asm.push0()
+    asm.call_native(compute_function_id("setStatusOverlayActive/vb"))
+    # Native arguments are pushed right to left: lighting=false, touch=true.
+    asm.push0()
+    asm.push1()
+    asm.call_native(compute_function_id("setUseDefaultKeyHandler/vbb"))
+    asm.ret_void()
+
+    asm.begin_function("repaint/v")
+    asm.push0()
+    asm.label("key")
+    asm.dup()
+    asm.push8(KEY_COUNT)
+    asm.sub_int32()
+    asm.test_lt_int32()
+    asm.jump_if_false("done")
+
+    asm.dup()
+    asm.push8(16)
+    asm.mul_int32()
+    # Stack: key, bit offset. Supply y=0 and x=key before the colour.
+    asm.push0()
+    asm.dup_offset(2)
+
+    # Each colour read supplies numBits before startBit (the VM's TOS).
+    for bit_offset, bit_count, shift, stack_offset in ((11, 5, 3, 3), (5, 6, 2, 4), (0, 5, 3, 5)):
+        asm.push8(bit_count)
+        asm.dup_offset(stack_offset)
+        if bit_offset:
+            asm.push8(bit_offset)
+            asm.add_int32()
+        asm.get_heap_bits()
+        asm.push8(shift)
+        asm.bit_shift_left()
+
+    asm.push16(255)
+    asm.call_native(compute_function_id("makeARGB/iiiii"))
+    asm.call_native(compute_function_id("fillPixel/viii"))
+    asm.drop()  # Discard bit offset; retain the key counter.
+    asm.push1()
+    asm.add_int32()
+    asm.jump("key")
+
+    asm.label("done")
+    asm.drop()
+    asm.ret_void()
+    emit_renderer_query_handler(asm, KEY_RENDERER)
+    return asm.build()
+
+
+def key_led_program_size() -> int:
+    """Return the byte offset where the renderer's 48-byte pixel heap begins."""
+    return len(key_led_program())

--- a/src/blocksd/littlefoot/keys.py
+++ b/src/blocksd/littlefoot/keys.py
@@ -10,6 +10,17 @@ from blocksd.littlefoot.lifecycle import KEY_RENDERER, emit_renderer_query_handl
 KEY_COUNT = 24
 KEY_HEAP_SIZE = KEY_COUNT * 2
 
+# ROLI BlockConfigId::brightness, with BlockConfigManager's 0..100 range.
+_HARDWARE_BRIGHTNESS = 36
+_MAX_HARDWARE_BRIGHTNESS = 100
+
+
+def _emit_hardware_brightness(asm: BytecodeAssembler) -> None:
+    """Keep brightness scaling in the host RGB pipeline."""
+    asm.push_int(_MAX_HARDWARE_BRIGHTNESS)
+    asm.push_int(_HARDWARE_BRIGHTNESS)
+    asm.call_native(compute_function_id("setLocalConfig/vii"))
+
 
 @lru_cache(maxsize=1)
 def key_led_program() -> bytes:
@@ -21,6 +32,7 @@ def key_led_program() -> bytes:
     """
     asm = BytecodeAssembler(heap_size=KEY_HEAP_SIZE)
     asm.begin_function("initialise/v")
+    _emit_hardware_brightness(asm)
     asm.push0()
     asm.call_native(compute_function_id("setStatusOverlayActive/vb"))
     # Native arguments are pushed right to left: lighting=false, touch=true.
@@ -67,7 +79,7 @@ def key_led_program() -> bytes:
     asm.label("done")
     asm.drop()
     asm.ret_void()
-    emit_renderer_query_handler(asm, KEY_RENDERER)
+    emit_renderer_query_handler(asm, KEY_RENDERER, on_ready=_emit_hardware_brightness)
     return asm.build()
 
 

--- a/src/blocksd/littlefoot/lifecycle.py
+++ b/src/blocksd/littlefoot/lifecycle.py
@@ -2,19 +2,30 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from blocksd.littlefoot.assembler import BytecodeAssembler, compute_function_id
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 RENDERER_READY_MARKER = 0x424C4544
 BITMAP_RENDERER = 1
 KEY_RENDERER = 2
 
 
-def emit_renderer_query_handler(asm: BytecodeAssembler, renderer_kind: int) -> None:
+def emit_renderer_query_handler(
+    asm: BytecodeAssembler,
+    renderer_kind: int,
+    *,
+    on_ready: Callable[[BytecodeAssembler], None] | None = None,
+) -> None:
     """Answer matching host challenges with the supplied nonce.
 
     Callback arguments sit below the dummy return address on the VM stack.
     Answering from handleMessage also works when identical code is reuploaded
-    without another initialise callback.
+    without another initialise callback. Optional setup is emitted after
+    marker/kind validation and before the reply, preserving callback arguments.
     """
     asm.begin_function("handleMessage/viii")
     asm.dup_offset(1)
@@ -25,6 +36,9 @@ def emit_renderer_query_handler(asm: BytecodeAssembler, renderer_kind: int) -> N
     asm.push_int(renderer_kind)
     asm.sub_int32()
     asm.jump_if_true("ignore_query")
+
+    if on_ready is not None:
+        on_ready(asm)
 
     asm.dup_offset(3)  # Third callback argument: the host's nonce.
     asm.push_int(renderer_kind)

--- a/src/blocksd/littlefoot/lifecycle.py
+++ b/src/blocksd/littlefoot/lifecycle.py
@@ -1,0 +1,34 @@
+"""Execution challenges handled by device-side LED renderers."""
+
+from __future__ import annotations
+
+from blocksd.littlefoot.assembler import BytecodeAssembler, compute_function_id
+
+RENDERER_READY_MARKER = 0x424C4544
+BITMAP_RENDERER = 1
+KEY_RENDERER = 2
+
+
+def emit_renderer_query_handler(asm: BytecodeAssembler, renderer_kind: int) -> None:
+    """Answer matching host challenges with the supplied nonce.
+
+    Callback arguments sit below the dummy return address on the VM stack.
+    Answering from handleMessage also works when identical code is reuploaded
+    without another initialise callback.
+    """
+    asm.begin_function("handleMessage/viii")
+    asm.dup_offset(1)
+    asm.push32(RENDERER_READY_MARKER)
+    asm.sub_int32()
+    asm.jump_if_true("ignore_query")
+    asm.dup_offset(2)
+    asm.push_int(renderer_kind)
+    asm.sub_int32()
+    asm.jump_if_true("ignore_query")
+
+    asm.dup_offset(3)  # Third callback argument: the host's nonce.
+    asm.push_int(renderer_kind)
+    asm.push32(RENDERER_READY_MARKER)
+    asm.call_native(compute_function_id("sendMessageToHost/viii"))
+    asm.label("ignore_query")
+    asm.ret_void(3)

--- a/src/blocksd/littlefoot/programs.py
+++ b/src/blocksd/littlefoot/programs.py
@@ -1,9 +1,8 @@
 """Pre-assembled LittleFoot programs for ROLI Blocks devices.
 
 BitmapLEDProgram: reads RGB565 pixel data from the device heap and
-paints the 15x15 LED grid. This is the program that enables host-side
-LED control — the host writes pixel data to the heap via SharedDataChange,
-and this program renders it on every repaint cycle (~25 Hz).
+paints the 15x15 LED grid. Host uploads target the inactive pixel bank.
+Presentation messages select a complete bank, acknowledged after repaint.
 """
 
 from __future__ import annotations
@@ -11,7 +10,13 @@ from __future__ import annotations
 from functools import lru_cache
 
 from blocksd.littlefoot.assembler import BytecodeAssembler, compute_function_id
-from blocksd.littlefoot.lifecycle import BITMAP_RENDERER, emit_renderer_query_handler
+from blocksd.littlefoot.bitmap_lifecycle import (
+    BITMAP_FRAME_BYTES,
+    BITMAP_GLOBALS,
+    emit_bitmap_message_handler,
+    emit_bitmap_repaint_begin,
+    emit_bitmap_repaint_end,
+)
 
 # Native function IDs (computed from signatures)
 _MAKE_ARGB = compute_function_id("makeARGB/iiiii")
@@ -21,20 +26,21 @@ _FILL_PIXEL = compute_function_id("fillPixel/viii")
 _COLS = 15
 _ROWS = 15
 _BITS_PER_PIXEL = 16
-_HEAP_SIZE = _COLS * _ROWS * 2  # 450 bytes (RGB565)
+_HEAP_SIZE = BITMAP_FRAME_BYTES * 2  # Two RGB565 banks.
 
 
 @lru_cache(maxsize=1)
 def bitmap_led_program() -> bytes:
     """Assemble the BitmapLEDProgram bytecode.
 
-    Equivalent LittleFoot source:
-        #heapsize: 450
+    Equivalent LittleFoot pixel loop (the message lifecycle selects activeBank):
+        #heapsize: 900
+        int activeBank;
 
         void repaint() {
             for (int y = 0; y < 15; ++y)
                 for (int x = 0; x < 15; ++x) {
-                    int bit = (x + y * 15) * 16;
+                    int bit = (activeBank * 225 + x + y * 15) * 16;
                     fillPixel(makeARGB(255,
                         getHeapBits(bit, 5) << 3,
                         getHeapBits(bit + 5, 6) << 2,
@@ -48,14 +54,16 @@ def bitmap_led_program() -> bytes:
     - callNative: stack[0] = first arg after flush
     - Built-in opcodes (getHeapBits): TOS = first arg, *stack++ = second arg
     """
-    asm = BytecodeAssembler(heap_size=_HEAP_SIZE)
+    asm = BytecodeAssembler(heap_size=_HEAP_SIZE, num_globals=BITMAP_GLOBALS)
     asm.begin_function("initialise/v")
     asm.push0()
     asm.call_native(compute_function_id("setStatusOverlayActive/vb"))
     asm.ret_void()
 
     asm.begin_function("repaint/v")
+    emit_bitmap_repaint_begin(asm)
 
+    # Stack comments below omit the latched frame context and bank bit base.
     # --- Outer loop: for (y = 0; y < 15; y++) ---
     asm.push0()  # y = 0                          stack: [y]
 
@@ -84,6 +92,8 @@ def bitmap_led_program() -> bytes:
     asm.add_int32()  # x + y*15                    stack: [y, x, x+y*15]
     asm.push8(_BITS_PER_PIXEL)  #                  stack: [y, x, x+y*15, 16]
     asm.mul_int32()  # bit                         stack: [y, x, bit]
+    asm.dup_offset(3)  # Latched bank bit base below y and x.
+    asm.add_int32()
 
     # --- fillPixel(makeARGB(255, r, g, b), x, y) ---
     # Push args RTL: y (3rd), x (2nd), then makeARGB result (1st)
@@ -149,9 +159,10 @@ def bitmap_led_program() -> bytes:
 
     asm.label("y_end")
     asm.drop()  # discard y                        stack: []
+    emit_bitmap_repaint_end(asm)
     asm.ret_void(0)
 
-    emit_renderer_query_handler(asm, BITMAP_RENDERER)
+    emit_bitmap_message_handler(asm)
     return asm.build()
 
 

--- a/src/blocksd/littlefoot/programs.py
+++ b/src/blocksd/littlefoot/programs.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from functools import lru_cache
 
 from blocksd.littlefoot.assembler import BytecodeAssembler, compute_function_id
+from blocksd.littlefoot.lifecycle import BITMAP_RENDERER, emit_renderer_query_handler
 
 # Native function IDs (computed from signatures)
 _MAKE_ARGB = compute_function_id("makeARGB/iiiii")
@@ -48,6 +49,11 @@ def bitmap_led_program() -> bytes:
     - Built-in opcodes (getHeapBits): TOS = first arg, *stack++ = second arg
     """
     asm = BytecodeAssembler(heap_size=_HEAP_SIZE)
+    asm.begin_function("initialise/v")
+    asm.push0()
+    asm.call_native(compute_function_id("setStatusOverlayActive/vb"))
+    asm.ret_void()
+
     asm.begin_function("repaint/v")
 
     # --- Outer loop: for (y = 0; y < 15; y++) ---
@@ -145,6 +151,7 @@ def bitmap_led_program() -> bytes:
     asm.drop()  # discard y                        stack: []
     asm.ret_void(0)
 
+    emit_renderer_query_handler(asm, BITMAP_RENDERER)
     return asm.build()
 
 

--- a/src/blocksd/protocol/builder.py
+++ b/src/blocksd/protocol/builder.py
@@ -122,3 +122,13 @@ def build_config_request_user_sync(device_index: int) -> bytes:
     builder.write_sysex_header(device_index)
     builder.config_request_user_sync()
     return builder.build()
+
+
+def build_program_event(device_index: int, data: tuple[int, int, int]) -> bytes:
+    """Send three signed 32-bit arguments to the program's handleMessage callback."""
+    builder = HostPacketBuilder()
+    builder.write_sysex_header(device_index)
+    builder.writer.write_bits(MessageFromHost.PROGRAM_EVENT, BitSize.MESSAGE_TYPE)
+    for value in data:
+        builder.writer.write_bits(value & 0xFFFFFFFF, 32)
+    return builder.build()

--- a/src/blocksd/protocol/builder.py
+++ b/src/blocksd/protocol/builder.py
@@ -56,6 +56,7 @@ class HostPacketBuilder:
 
         self._writer.write_bits(MessageFromHost.CONFIG_MESSAGE, BitSize.MESSAGE_TYPE)
         self._writer.write_bits(ConfigCommand.REQUEST_CONFIG, BitSize.CONFIG_COMMAND)
+        self._writer.write_bits(0, 32)  # Reserved address precedes the requested item.
         self._writer.write_bits(item, BitSize.CONFIG_ITEM_INDEX)
 
     def config_request_user_sync(self) -> None:

--- a/src/blocksd/protocol/data_change.py
+++ b/src/blocksd/protocol/data_change.py
@@ -222,6 +222,14 @@ def encode_regions_limited(
     """
     for region in regions:
         if region.is_skip:
+            many, remainder = divmod(region.count, _MANY_MAX)
+            skip_bits = many * (BitSize.DATA_CHANGE_COMMAND + BitSize.BYTE_COUNT_MANY)
+            if remainder:
+                skip_bits += BitSize.DATA_CHANGE_COMMAND + (
+                    BitSize.BYTE_COUNT_FEW if remainder <= _FEW_MAX else BitSize.BYTE_COUNT_MANY
+                )
+            if not encoder._writer.has_capacity(skip_bits + _END_BITS):
+                return False
             encoder.skip_bytes(region.count)
             continue
 

--- a/src/blocksd/protocol/remote_heap.py
+++ b/src/blocksd/protocol/remote_heap.py
@@ -64,6 +64,7 @@ class RemoteHeap:
 
     def __init__(self, size: int) -> None:
         self._size = size
+        self._generation = 0
         self._device_state: list[int] = [_UNKNOWN] * size
         self._target = bytearray(size)
         self._messages: deque[_InFlightMessage] = deque()
@@ -74,6 +75,11 @@ class RemoteHeap:
     @property
     def size(self) -> int:
         return self._size
+
+    @property
+    def generation(self) -> int:
+        """Monotonic epoch of the confirmed device state."""
+        return self._generation
 
     @property
     def is_dirty(self) -> bool:
@@ -104,6 +110,7 @@ class RemoteHeap:
 
     def reset(self) -> None:
         """Reset all state — device becomes unknown, target zeroed."""
+        self._generation += 1
         self._device_state = [_UNKNOWN] * self._size
         self._target = bytearray(self._size)
         self._messages.clear()
@@ -116,6 +123,7 @@ class RemoteHeap:
 
         Clears in-flight messages since they'll never be ACK'd.
         """
+        self._generation += 1
         self._device_state = [_UNKNOWN] * self._size
         self._messages.clear()
         self._packet_index = (

--- a/src/blocksd/protocol/remote_heap.py
+++ b/src/blocksd/protocol/remote_heap.py
@@ -67,6 +67,7 @@ class RemoteHeap:
         self._generation = 0
         self._device_state: list[int] = [_UNKNOWN] * size
         self._target = bytearray(size)
+        self._transfer_target: bytes | None = None
         self._messages: deque[_InFlightMessage] = deque()
         self._packet_index: int = 0
         self._last_packet_index_received: int = 0
@@ -85,9 +86,11 @@ class RemoteHeap:
     def is_dirty(self) -> bool:
         """True if target differs from expected device state.
 
-        A blank target (all zeros) is never dirty — matches the ROLI
-        isAllZero guard that prevents flushing an empty heap.
+        Without an active transfer, a blank target (all zeros) is never dirty.
+        This matches the ROLI isAllZero guard against flushing an empty heap.
         """
+        if self._transfer_target is not None:
+            return True
         if not any(self._target):
             return False
         return self._expected_state() != self._target
@@ -110,6 +113,7 @@ class RemoteHeap:
 
     def reset(self) -> None:
         """Reset all state — device becomes unknown, target zeroed."""
+        self._transfer_target = None
         self._generation += 1
         self._device_state = [_UNKNOWN] * self._size
         self._target = bytearray(self._size)
@@ -123,6 +127,7 @@ class RemoteHeap:
 
         Clears in-flight messages since they'll never be ACK'd.
         """
+        self._transfer_target = None
         self._generation += 1
         self._device_state = [_UNKNOWN] * self._size
         self._messages.clear()
@@ -150,12 +155,18 @@ class RemoteHeap:
 
         # Match ROLI isAllZero check: don't send changes if target is blank.
         # This avoids flushing 7200 bytes of zeros before any program is loaded.
-        if not any(self._target):
-            return None
+        if self._transfer_target is None:
+            if not any(self._target):
+                return None
+            # Finish this snapshot before newer frames can replace its prefix.
+            # The desired target keeps coalescing while packets are in flight.
+            self._transfer_target = bytes(self._target)
 
-        expected = self._expected_state()
-        regions = compute_diff(expected, self._target)
+        target = self._transfer_target
+        expected = self._expected_state(target)
+        regions = compute_diff(expected, target)
         if not regions:
+            self._transfer_target = None
             return None
 
         if self._messages:
@@ -171,7 +182,7 @@ class RemoteHeap:
         builder.begin_data_changes(packet_index)
 
         encoder = DataChangeEncoder(builder.writer)
-        is_complete = encode_regions_limited(encoder, regions, self._target, result_state)
+        is_complete = encode_regions_limited(encoder, regions, target, result_state)
         if result_state == expected:
             return None
         encoder.end(is_last=is_complete)
@@ -190,6 +201,8 @@ class RemoteHeap:
             )
         )
         self._packet_index = (packet_index + 1) & _COUNTER_MASK
+        if is_complete:
+            self._transfer_target = None
         return packet
 
     def handle_ack(self, packet_index: int) -> bool:
@@ -241,7 +254,7 @@ class RemoteHeap:
             return oldest.packet_data
         return None
 
-    def _expected_state(self) -> bytearray:
+    def _expected_state(self, target: bytes | bytearray | None = None) -> bytearray:
         """Get the optimistic expected device state.
 
         If messages are in-flight, returns the tail message's result state
@@ -253,7 +266,9 @@ class RemoteHeap:
         """
         if self._messages:
             return bytearray(self._messages[-1].result_state)
+        if target is None:
+            target = self._target
         return bytearray(
-            (self._target[i] ^ 0xFF) if b == _UNKNOWN else (b & 0xFF)
+            (target[i] ^ 0xFF) if b == _UNKNOWN else (b & 0xFF)
             for i, b in enumerate(self._device_state)
         )

--- a/src/blocksd/topology/device_group.py
+++ b/src/blocksd/topology/device_group.py
@@ -28,6 +28,7 @@ from blocksd.device.registry import (
     supports_bitmap_led_program,
     supports_key_led_program,
 )
+from blocksd.led.buffered_program import BufferedLEDProgram
 from blocksd.led.program import LEDProgram
 from blocksd.littlefoot.keys import KEY_HEAP_SIZE, key_led_program
 from blocksd.littlefoot.lifecycle import BITMAP_RENDERER, KEY_RENDERER
@@ -320,7 +321,9 @@ class DeviceGroup:
         if len(pixel_data) != 450:
             return False
         if uid not in self._led_programs:
-            self._led_programs[uid] = LEDProgram(heap, bitmap_led_program(), BITMAP_RENDERER, 450)
+            self._led_programs[uid] = BufferedLEDProgram(
+                heap, bitmap_led_program(), BITMAP_RENDERER, 450
+            )
         self._led_programs[uid].set_frame(pixel_data)
         self._flush_heap(uid, heap, time.monotonic())
         return True

--- a/src/blocksd/topology/device_group.py
+++ b/src/blocksd/topology/device_group.py
@@ -127,10 +127,23 @@ class DeviceGroup:
         self._send_serial_request()
         self._send_topology_request()
 
+        next_tick = self._serial_start_time
         try:
             while self.state != GroupState.FAILED and self.conn.is_open:
-                await self._tick()
-                await asyncio.sleep(TICK_INTERVAL)
+                now = time.monotonic()
+                if now >= next_tick:
+                    self._lifecycle_timer(now)
+                    # Advance the deadline, rather than adding work time to the
+                    # cadence or replaying every missed lifecycle tick.
+                    next_tick += (int((now - next_tick) / TICK_INTERVAL) + 1) * TICK_INTERVAL
+                if self.state == GroupState.FAILED or not self.conn.is_open:
+                    break
+                message = await self.conn.recv(timeout=max(0.0, next_tick - time.monotonic()))
+                if message is not None:
+                    self._process_message(message)
+                # A transport may return queued messages without suspending.
+                # Yield cooperatively so bursts cannot monopolize the loop.
+                await asyncio.sleep(0)
         except asyncio.CancelledError:
             pass
         finally:
@@ -138,22 +151,6 @@ class DeviceGroup:
             self.conn.close()
 
     # ── Packet processing ─────────────────────────────────────────────────
-
-    async def _tick(self) -> None:
-        """Process incoming messages + run lifecycle timer."""
-        # Drain all pending messages
-        for msg in self.conn.drain():
-            self._process_message(msg)
-
-        # Also try async recv with short timeout for any stragglers
-        while True:
-            msg = await self.conn.recv(timeout=0.01)
-            if msg is None:
-                break
-            self._process_message(msg)
-
-        now = time.monotonic()
-        self._lifecycle_timer(now)
 
     def _process_message(self, data: bytes) -> None:
         """Route an incoming SysEx message."""

--- a/src/blocksd/topology/device_group.py
+++ b/src/blocksd/topology/device_group.py
@@ -26,13 +26,18 @@ from blocksd.device.registry import (
     block_type_from_serial,
     heap_size_for_block,
     supports_bitmap_led_program,
+    supports_key_led_program,
 )
-from blocksd.littlefoot.programs import bitmap_led_program_size
+from blocksd.led.program import LEDProgram
+from blocksd.littlefoot.keys import KEY_HEAP_SIZE, key_led_program
+from blocksd.littlefoot.lifecycle import BITMAP_RENDERER, KEY_RENDERER
+from blocksd.littlefoot.programs import bitmap_led_program
 from blocksd.protocol.builder import (
     build_begin_api_mode,
     build_config_request,
     build_end_api_mode,
     build_ping,
+    build_program_event,
     build_request_topology,
 )
 from blocksd.protocol.constants import SERIAL_DUMP_REQUEST
@@ -58,36 +63,6 @@ DNA_PING_INTERVAL = 1.666  # ~1666ms for DNA-connected blocks
 SERIAL_REQUEST_INTERVAL = 0.3  # 300ms between serial dump requests
 SERIAL_TIMEOUT = 5.0  # give up serial after 5s
 TICK_INTERVAL = 0.2  # 200ms lifecycle timer (matches C++ timerInterval)
-
-
-def _build_green_fill() -> bytes:
-    """Fill 15x15 grid with green — fully unrolled, no loops or dupOffset.
-
-    Emits 225 hardcoded fillPixel calls. Large but guaranteed to work
-    since it only uses opcodes proven safe on firmware v1.1.0.
-    """
-    from blocksd.littlefoot.assembler import BytecodeAssembler, compute_function_id
-
-    make_argb = compute_function_id("makeARGB/iiiii")
-    fill_pixel = compute_function_id("fillPixel/viii")
-
-    asm = BytecodeAssembler(heap_size=0)
-    asm.begin_function("repaint/v")
-
-    for y in range(15):
-        for x in range(15):
-            # fillPixel(makeARGB(255, 0, 255, 0), x, y) — all args hardcoded
-            asm.push8(y)  # y (RTL: pushed first)
-            asm.push8(x)  # x
-            asm.push0()  # blue = 0
-            asm.push16(255)  # green = 255
-            asm.push0()  # red = 0
-            asm.push16(255)  # alpha = 255
-            asm.call_native(make_argb)
-            asm.call_native(fill_pixel)
-
-    asm.ret_void(0)
-    return asm.build()
 
 
 class GroupState(StrEnum):
@@ -127,6 +102,7 @@ class DeviceGroup:
         self._pings: dict[int, PingEntry] = {}  # uid → PingEntry
         self._end_api_sent: set[int] = set()  # UIDs that received endAPIMode this session
         self._heaps: dict[int, RemoteHeap] = {}  # uid → RemoteHeap
+        self._led_programs: dict[int, LEDProgram] = {}
         self._config: dict[int, dict[int, ConfigValue]] = {}  # uid → {item → ConfigValue}
 
         # Timing
@@ -319,10 +295,9 @@ class DeviceGroup:
             self._pings[uid] = PingEntry(uid, last_ack=now, last_ping_sent=now, connected_at=now)
             dev = self._devices.get(uid)
             if dev:
-                # Create a RemoteHeap and load LED program
+                # Leave the factory program active until a lighting request arrives.
                 if uid not in self._heaps:
                     self._heaps[uid] = RemoteHeap(heap_size_for_block(dev.block_type))
-                    self._load_led_program(uid)
                 self._request_config_sync(uid)
                 for cb in self.on_device_added:
                     cb(dev)
@@ -342,32 +317,33 @@ class DeviceGroup:
         heap = self._heaps.get(uid)
         if dev is None or heap is None or not supports_bitmap_led_program(dev.block_type):
             return False
-        offset = bitmap_led_program_size()
-        if offset + len(pixel_data) > heap.size:
+        if len(pixel_data) != 450:
             return False
-        heap.set_bytes(offset, pixel_data)
+        if uid not in self._led_programs:
+            self._led_programs[uid] = LEDProgram(heap, bitmap_led_program(), BITMAP_RENDERER, 450)
+        self._led_programs[uid].set_frame(pixel_data)
         self._flush_heap(uid, heap, time.monotonic())
         return True
 
-    def _load_led_program(self, uid: int) -> None:
-        """Load LED test program into a device's heap.
-
-        TODO: Replace with proper BitmapLEDProgram once firmware opcode
-        compatibility is resolved (getHeapBits 0x40 and dupOffset_01 0x11
-        are not supported on firmware v1.1.0).
-        """
+    def set_key_led_data(self, uid: int, pixel_data: bytes | bytearray) -> bool:
+        """Queue a 24-key RGB565 frame while retaining firmware MIDI handling."""
         dev = self._devices.get(uid)
         heap = self._heaps.get(uid)
-        if dev is None or heap is None:
-            return
-        if not supports_bitmap_led_program(dev.block_type):
-            return
-        # TODO: Replace with proper BitmapLEDProgram using firmware-safe opcodes
-        # For now, skip program upload — device keeps its default LED animation.
-        return
-        program = _build_green_fill()
-        heap.set_bytes(0, program)
-        log.debug("Loaded green fill program (%d bytes) for %s", len(program), dev.serial)
+        if dev is None or heap is None or not supports_key_led_program(dev.block_type):
+            return False
+        try:
+            version = tuple(int(part) for part in dev.version.rstrip("\x00").split("."))
+        except ValueError:
+            return False
+        if len(version) != 3 or version < (1, 3, 0) or len(pixel_data) != KEY_HEAP_SIZE:
+            return False
+        if uid not in self._led_programs:
+            self._led_programs[uid] = LEDProgram(
+                heap, key_led_program(), KEY_RENDERER, KEY_HEAP_SIZE
+            )
+        self._led_programs[uid].set_frame(pixel_data)
+        self._flush_heap(uid, heap, time.monotonic())
+        return True
 
     def _flush_heaps(self, now: float) -> None:
         """Send pending heap changes and retransmit timed-out packets."""
@@ -383,6 +359,9 @@ class DeviceGroup:
         dev = self._devices.get(uid)
         if dev is None:
             return
+
+        if (program := self._led_programs.get(uid)) and (query := program.advance(now)):
+            self.conn.send(build_program_event(dev.topology_index, query))
 
         retransmit = heap.get_retransmit(now)
         if retransmit is not None:
@@ -451,6 +430,7 @@ class DeviceGroup:
         dev = self._devices.pop(uid, None)
         self._pings.pop(uid, None)
         self._heaps.pop(uid, None)
+        self._led_programs.pop(uid, None)
         self._config.pop(uid, None)
         # NOTE: _end_api_sent is intentionally NOT cleared here.
         # If the device reappears (e.g. transient DNA glitch), we skip
@@ -554,7 +534,8 @@ class DeviceGroup:
         uid = self._uid_from_index(device_index)
         if uid:
             self._update_api_ping(uid)
-            if (heap := self._heaps.get(uid)) and heap.handle_ack(counter):
+            if heap := self._heaps.get(uid):
+                heap.handle_ack(counter)
                 self._flush_heap(uid, heap, time.monotonic())
 
     def on_firmware_update_ack(self, device_index: int, code: int, detail: int) -> None:  # noqa: ARG002
@@ -596,7 +577,11 @@ class DeviceGroup:
     def on_program_event(
         self, device_index: int, timestamp: int, data: tuple[int, int, int]
     ) -> None:
-        pass
+        uid = self._uid_from_index(device_index)
+        if (program := self._led_programs.get(uid)) is not None:
+            log.debug("Renderer event from %d at %d: %s", uid, timestamp, data)
+            program.on_ready(data)
+            self._flush_heap(uid, program.heap, time.monotonic())
 
     def on_config_update(
         self, device_index: int, item: int, value: int, min_val: int, max_val: int

--- a/src/blocksd/topology/manager.py
+++ b/src/blocksd/topology/manager.py
@@ -82,6 +82,10 @@ class TopologyManager:
                     return dev
         return None
 
+    def set_key_led_data(self, uid: int, pixel_data: bytes | bytearray) -> bool:
+        """Route an RGB565 key frame to its connected LUMI."""
+        return any(entry.group.set_key_led_data(uid, pixel_data) for entry in self._groups.values())
+
     def get_config(self, uid: int) -> dict[int, ConfigValue]:
         """Get all known config values for a device."""
         for entry in self._groups.values():

--- a/tests/cli/test_led.py
+++ b/tests/cli/test_led.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
-from unittest.mock import patch
+import asyncio
+import signal
+from unittest.mock import Mock, patch
 
+import pytest
 from typer.testing import CliRunner
 
 from blocksd.cli.app import app
-from blocksd.cli.led import _parse_color
-from blocksd.led.bitmap import Color
+from blocksd.cli.led import _parse_color, _run_with_pattern
+from blocksd.device.models import BlockType, DeviceInfo
+from blocksd.led.bitmap import Color, LEDGrid
 
 runner = CliRunner()
 
@@ -127,3 +131,118 @@ class TestLedCommandsRun:
         result = runner.invoke(app, ["led", "checkerboard", "ff0000", "00ff00", "--size", "3"])
         assert result.exit_code == 0
         mock_run.assert_called_once()
+
+
+class TestKeyLighting:
+    def test_help_explains_standalone_lifetime(self):
+        result = runner.invoke(app, ["led", "keys", "--help"])
+        assert result.exit_code == 0
+        assert "Stop the daemon" in result.output
+        assert "Ctrl+C" in result.output
+
+    @pytest.mark.parametrize("args", [[], ["rainbow"], ["ff0000"]])
+    @patch("blocksd.cli.led._run_with_pattern")
+    def test_keys_routes_a_24_key_pattern(self, mock_run, args):
+        result = runner.invoke(app, ["led", "keys", *args])
+        assert result.exit_code == 0
+        assert mock_run.call_args.kwargs["key_lighting"] is True
+        grid = LEDGrid(cols=24, rows=1)
+        mock_run.call_args.args[0](grid)
+        assert len(grid.heap_data) == 48
+        assert grid.heap_data[:2] == bytes.fromhex("1f00")
+        if args == ["ff0000"]:
+            assert grid.heap_data == bytes.fromhex("1f00") * 24
+        else:
+            assert grid.heap_data[24:26] == bytes.fromhex("e0ff")
+
+    @patch("blocksd.cli.led._run_with_pattern")
+    def test_invalid_color_does_not_start_device_manager(self, mock_run):
+        result = runner.invoke(app, ["led", "keys", "bad"])
+        assert result.exit_code == 1
+        mock_run.assert_not_called()
+
+    @pytest.mark.parametrize("key_lighting", [True, False])
+    def test_runner_keeps_key_and_bitmap_devices_separate(self, key_lighting):
+        manager = Mock()
+        manager.on_device_added = []
+        manager.on_device_removed = []
+        with (
+            patch("blocksd.topology.manager.TopologyManager", return_value=manager),
+            patch("blocksd.logging.setup_logging"),
+            patch("blocksd.cli.led.asyncio.run", side_effect=lambda coroutine: coroutine.close()),
+        ):
+            _run_with_pattern(lambda grid: grid.fill(Color(255, 0, 0)), key_lighting=key_lighting)
+        for uid, block_type in enumerate(BlockType):
+            manager.on_device_added[0](
+                DeviceInfo(
+                    uid=uid,
+                    topology_index=uid,
+                    serial="DEVICE",
+                    block_type=block_type,
+                    version="1.3.9",
+                )
+            )
+        if key_lighting:
+            manager.set_key_led_data.assert_called_once()
+            assert manager.set_key_led_data.call_args.args[1] == bytes.fromhex("1f00") * 24
+            manager.set_led_data.assert_not_called()
+        else:
+            assert manager.set_led_data.call_count == 2
+            assert manager.set_led_data.call_args.args[1] == bytes.fromhex("1f00") * 225
+            manager.set_key_led_data.assert_not_called()
+
+    @pytest.mark.parametrize("disconnect_before_version", [False, True])
+    def test_command_waits_for_firmware_and_cancels_on_disconnect(
+        self, monkeypatch, disconnect_before_version
+    ):
+        manager = Mock()
+        manager.on_device_added = []
+        manager.on_device_removed = []
+        stopped = False
+        device = DeviceInfo(
+            uid=7, topology_index=1, serial="LKB000", block_type=BlockType.LUMI_KEYS
+        )
+        signals = {}
+
+        async def manager_run():
+            nonlocal stopped
+            try:
+                manager.on_device_added[0](device)
+                await asyncio.sleep(0.06)
+                manager.set_key_led_data.assert_not_called()
+                if disconnect_before_version:
+                    manager.on_device_removed[0](device)
+                device.version = "1.3.9"
+                await asyncio.sleep(0.12)
+                if disconnect_before_version:
+                    manager.set_key_led_data.assert_not_called()
+                else:
+                    manager.set_key_led_data.assert_called_once_with(7, bytes.fromhex("1f00") * 24)
+                signals[signal.SIGINT]()
+                await asyncio.Future()
+            finally:
+                stopped = True
+
+        manager.run = manager_run
+
+        def run_command(coroutine):
+            with asyncio.Runner() as async_runner:
+                loop = async_runner.get_loop()
+                monkeypatch.setattr(
+                    loop, "add_signal_handler", lambda sig, cb: signals.update({sig: cb})
+                )
+
+                async def bounded():
+                    async with asyncio.timeout(1):
+                        await coroutine
+
+                async_runner.run(bounded())
+
+        with (
+            patch("blocksd.topology.manager.TopologyManager", return_value=manager),
+            patch("blocksd.logging.setup_logging"),
+            patch("blocksd.cli.led.asyncio.run", side_effect=run_command),
+        ):
+            result = runner.invoke(app, ["led", "keys", "ff0000"])
+        assert result.exit_code == 0, result.exception
+        assert stopped

--- a/tests/led/test_buffered_program.py
+++ b/tests/led/test_buffered_program.py
@@ -1,0 +1,183 @@
+"""Bitmap bank ownership survives asynchronous upload and presentation replies."""
+
+from __future__ import annotations
+
+import pytest
+
+from blocksd.led.buffered_program import BufferedLEDProgram
+from blocksd.littlefoot.bitmap_lifecycle import NOT_READY, PRESENT_BASE, PRESENTED_BASE
+from blocksd.littlefoot.lifecycle import BITMAP_RENDERER
+from blocksd.littlefoot.programs import bitmap_led_program
+from blocksd.protocol.remote_heap import RemoteHeap
+from tests.led.test_program import finish_upload
+
+
+def make_program() -> tuple[RemoteHeap, BufferedLEDProgram]:
+    heap = RemoteHeap(7200)
+    return heap, BufferedLEDProgram(heap, bitmap_led_program(), BITMAP_RENDERER, 450)
+
+
+def bank(heap: RemoteHeap, program: BufferedLEDProgram, index: int) -> bytes:
+    start = len(program.code) + 450 * index
+    return heap.target[start : start + 450]
+
+
+def acknowledge_present(program: BufferedLEDProgram, request: tuple[int, int, int]) -> None:
+    program.on_ready((PRESENTED_BASE | (request[0] & 1), request[1], request[2]))
+
+
+def ready(heap: RemoteHeap, program: BufferedLEDProgram) -> tuple[int, int, int]:
+    finish_upload(heap)
+    request = program.advance(0)
+    assert request is not None
+    program.on_ready(request)
+    assert program.ready
+    return request
+
+
+def test_first_frame_waits_for_ready_and_complete_bank_ack():
+    heap, program = make_program()
+    pixels = bytes(range(225)) * 2
+    program.set_frame(pixels)
+    assert program.advance(0) is None
+    assert bank(heap, program, 0) == bank(heap, program, 1) == bytes(450)
+    query = ready(heap, program)
+    assert bank(heap, program, 0) == bytes(450)
+    assert bank(heap, program, 1) == pixels
+    assert program.advance(1) is None
+    while heap.send_changes(1) is not None:
+        pass
+    assert heap.in_flight_count
+    assert program.advance(2) is None
+    finish_upload(heap)
+    request = program.advance(3)
+    assert request == (PRESENT_BASE | 1, query[2], 1)
+    acknowledge_present(program, request)
+    assert program.advance(4) is None
+
+
+def test_pending_frame_is_immutable_and_latest_frame_uses_released_bank():
+    heap, program = make_program()
+    first, second, latest = (bytes([value]) * 450 for value in (1, 2, 3))
+    program.set_frame(first)
+    ready(heap, program)
+    program.set_frame(second)
+    program.set_frame(latest)
+    assert bank(heap, program, 0) == bytes(450)
+    assert bank(heap, program, 1) == first
+    finish_upload(heap)
+    request = program.advance(1)
+    assert request is not None
+    program.set_frame(second)
+    program.set_frame(latest)
+    assert bank(heap, program, 0) == bytes(450)
+    assert bank(heap, program, 1) == first
+    acknowledge_present(program, request)
+    assert bank(heap, program, 1) == first
+    assert bank(heap, program, 0) == latest
+    finish_upload(heap)
+    next_request = program.advance(2)
+    assert next_request == (PRESENT_BASE, request[1], 2)
+    acknowledge_present(program, next_request)
+    assert program.advance(3) is None
+
+
+def test_lost_presentation_reply_retries_without_rewriting_either_bank():
+    heap, program = make_program()
+    program.set_frame(bytes([7]) * 450)
+    ready(heap, program)
+    finish_upload(heap)
+    request = program.advance(1)
+    assert request is not None
+    target = heap.target
+    program.set_frame(bytes([8]) * 450)
+    assert program.advance(1.1) is None
+    assert program.advance(1.25) == request
+    assert heap.target == target
+    assert not heap.is_dirty
+    acknowledge_present(program, request)
+    assert bank(heap, program, 0) == bytes([8]) * 450
+
+
+def test_unsolicited_wrong_bank_epoch_and_sequence_replies_do_not_release_bank():
+    heap, program = make_program()
+    program.set_frame(bytes([1]) * 450)
+    query = ready(heap, program)
+    # Even the right tuple is inert before PRESENT was sent.
+    early = (PRESENTED_BASE | 1, query[2], 1)
+    program.on_ready(early)
+    program.set_frame(bytes([2]) * 450)
+    assert bank(heap, program, 0) == bytes(450)
+    finish_upload(heap)
+    request = program.advance(1)
+    assert request is not None
+    for response in [
+        (PRESENTED_BASE, request[1], request[2]),
+        (PRESENTED_BASE | 1, request[1] + 1, request[2]),
+        (PRESENTED_BASE | 1, request[1], request[2] + 1),
+        query,
+        (NOT_READY, request[1] + 1, request[2]),
+        (NOT_READY, request[1], request[2] + 1),
+    ]:
+        program.on_ready(response)
+        assert bank(heap, program, 0) == bytes(450)
+        assert program.ready
+    acknowledge_present(program, request)
+    assert bank(heap, program, 0) == bytes([2]) * 450
+    target = heap.target
+    acknowledge_present(program, request)
+    assert heap.target == target
+
+
+@pytest.mark.parametrize("reset", ["reset", "reset_device_state", "unknown_ack", "vm_restart"])
+@pytest.mark.parametrize("presented", [False, True])
+def test_reset_renegotiates_session_before_uploading_latest_frame(reset: str, presented: bool):
+    heap, program = make_program()
+    first, latest = bytes([1]) * 450, bytes([2]) * 450
+    program.set_frame(first)
+    old_query = ready(heap, program)
+    finish_upload(heap)
+    old_request = program.advance(1)
+    assert old_request is not None
+    if presented:
+        acknowledge_present(program, old_request)
+        program.set_frame(latest)
+        finish_upload(heap)
+        old_request = program.advance(1.5)
+        assert old_request is not None and old_request[0] == PRESENT_BASE
+    program.set_frame(latest)
+    if reset == "vm_restart":
+        program.on_ready((NOT_READY, old_request[1], old_request[2]))
+    elif reset == "unknown_ack":
+        assert not heap.handle_ack((heap.packet_index + 99) & 0x3FF)
+    else:
+        getattr(heap, reset)()
+    assert program.advance(2) is None
+    assert not program.ready
+    assert bank(heap, program, 0) == bank(heap, program, 1) == bytes(450)
+    acknowledge_present(program, old_request)
+    program.on_ready(old_query)
+    assert not program.ready
+    finish_upload(heap)
+    query = program.advance(3)
+    assert query is not None and query[2] != old_query[2]
+    program.on_ready(query)
+    assert program.ready
+    assert bank(heap, program, 0) == bytes(450)
+    assert bank(heap, program, 1) == latest
+    finish_upload(heap)
+    request = program.advance(4)
+    assert request == (PRESENT_BASE | 1, query[2], 1)
+    acknowledge_present(program, old_request)
+    assert program.advance(4.25) == request
+    acknowledge_present(program, request)
+    assert program.advance(5) is None
+
+
+def test_invalid_frame_and_unchanged_visible_frame_do_not_start_transfers():
+    heap, program = make_program()
+    ready(heap, program)
+    assert not program.set_frame(b"bad")
+    assert program.set_frame(bytes(450))
+    assert program.advance(1) is None
+    assert not heap.is_dirty

--- a/tests/led/test_program.py
+++ b/tests/led/test_program.py
@@ -1,0 +1,159 @@
+"""Renderer challenges prevent stale readiness and startup pixel loss."""
+
+import pytest
+
+from blocksd.led.program import LEDProgram
+from blocksd.littlefoot.lifecycle import BITMAP_RENDERER, RENDERER_READY_MARKER
+from blocksd.littlefoot.programs import bitmap_led_program
+from blocksd.protocol.remote_heap import RemoteHeap
+
+
+def finish_upload(heap: RemoteHeap) -> None:
+    for _ in range(100):
+        heap.send_changes(1)
+        if heap.in_flight_count:
+            heap.handle_ack((heap.packet_index - 1) & 0x3FF)
+        if not heap.is_dirty and heap.in_flight_count == 0:
+            return
+    pytest.fail("Heap did not synchronize")
+
+
+def make_program() -> tuple[RemoteHeap, LEDProgram]:
+    heap = RemoteHeap(7200)
+    return heap, LEDProgram(heap, bitmap_led_program(), BITMAP_RENDERER, 450)
+
+
+def pixels_in(heap: RemoteHeap, program: LEDProgram) -> bytes:
+    return heap.target[len(program.code) : len(program.code) + 450]
+
+
+def test_challenge_waits_for_complete_upload_and_ack():
+    heap, program = make_program()
+    pixels = bytes([31, 0]) * 225
+    assert program.set_frame(pixels)
+    assert program.advance(0) is None
+    while heap.send_changes(1) is not None:
+        pass
+    assert heap.in_flight_count > 0
+    assert program.advance(1) is None
+    assert pixels_in(heap, program) == bytes(450)
+    finish_upload(heap)
+    query = program.advance(2)
+    assert query is not None
+    assert query[:2] == (RENDERER_READY_MARKER, BITMAP_RENDERER)
+    assert 0 < query[2] <= 0x7FFFFFFF
+    assert not program.ready
+    assert pixels_in(heap, program) == bytes(450)
+    program.on_ready(query)
+    assert program.ready
+    assert pixels_in(heap, program) == pixels
+
+
+def test_startup_coalesces_frames_and_rejects_unrelated_events():
+    heap, program = make_program()
+    assert program.set_frame(bytes([31, 0]) * 225)
+    latest = bytes([0, 248]) * 225
+    assert program.set_frame(latest)
+    assert not program.set_frame(b"invalid")
+    finish_upload(heap)
+    query = program.advance(0)
+    assert query is not None
+    for reply in [(0, query[1], query[2]), (query[0], 2, query[2]), (query[0], query[1], 0)]:
+        program.on_ready(reply)
+        assert not program.ready
+    program.on_ready(query)
+    assert pixels_in(heap, program) == latest
+
+
+def test_unanswered_challenge_retries_without_reuploading_code():
+    heap, program = make_program()
+    finish_upload(heap)
+    query = program.advance(0)
+    assert query is not None
+    assert program.advance(0.1) is None
+    assert program.advance(0.25) == query
+    assert not heap.is_dirty
+    assert heap.in_flight_count == 0
+    program.on_ready(query)
+    assert program.advance(100) is None
+
+
+def test_live_frames_and_duplicate_replies_do_not_reload_or_erase_pixels():
+    heap, program = make_program()
+    finish_upload(heap)
+    query = program.advance(0)
+    assert query is not None
+    program.on_ready(query)
+    assert program.set_frame(bytes([255]) * 450)
+    finish_upload(heap)
+    program.on_ready(query)
+    assert pixels_in(heap, program) == bytes([255]) * 450
+    assert heap.target[: len(program.code)] == program.code
+    assert not heap.is_dirty
+    assert program.advance(10) is None
+
+
+@pytest.mark.parametrize("full_reset", [False, True])
+@pytest.mark.parametrize("phase", ["uploading", "querying", "live"])
+def test_state_loss_rechallenges_and_preserves_latest_pixels(full_reset, phase):
+    heap, program = make_program()
+    latest = bytes([31, 0]) * 225
+    program.set_frame(latest)
+    old_query = None
+    if phase != "uploading":
+        finish_upload(heap)
+        old_query = program.advance(0)
+        assert old_query is not None
+        if phase == "live":
+            program.on_ready(old_query)
+            finish_upload(heap)
+    else:
+        heap.send_changes(1)
+
+    if full_reset:
+        heap.reset()
+    else:
+        heap.reset_device_state()
+    assert program.advance(1) is None
+    assert not program.ready
+    assert pixels_in(heap, program) == bytes(450)
+    assert heap.target[: len(program.code)] == program.code
+    if old_query:
+        program.on_ready(old_query)
+        assert not program.ready
+    finish_upload(heap)
+    new_query = program.advance(2)
+    assert new_query is not None
+    if old_query:
+        assert new_query != old_query
+        program.on_ready(old_query)
+        assert not program.ready
+    program.on_ready(new_query)
+    assert program.ready
+    assert pixels_in(heap, program) == latest
+
+
+def test_event_and_frame_entrypoints_detect_reset_before_using_readiness():
+    heap, program = make_program()
+    finish_upload(heap)
+    query = program.advance(0)
+    assert query is not None
+    program.on_ready(query)
+    heap.reset_device_state()
+    program.on_ready(query)
+    assert not program.ready
+    assert pixels_in(heap, program) == bytes(450)
+    program.set_frame(bytes([255]) * 450)
+    assert pixels_in(heap, program) == bytes(450)
+
+
+def test_unknown_ack_invalidates_outstanding_challenge():
+    heap, program = make_program()
+    finish_upload(heap)
+    query = program.advance(0)
+    assert query is not None
+    assert not heap.handle_ack((heap.packet_index + 100) & 0x3FF)
+    program.on_ready(query)
+    assert not program.ready
+    assert program.advance(1) is None
+    assert heap.is_dirty

--- a/tests/led/test_program.py
+++ b/tests/led/test_program.py
@@ -3,8 +3,8 @@
 import pytest
 
 from blocksd.led.program import LEDProgram
-from blocksd.littlefoot.lifecycle import BITMAP_RENDERER, RENDERER_READY_MARKER
-from blocksd.littlefoot.programs import bitmap_led_program
+from blocksd.littlefoot.keys import key_led_program
+from blocksd.littlefoot.lifecycle import KEY_RENDERER, RENDERER_READY_MARKER
 from blocksd.protocol.remote_heap import RemoteHeap
 
 
@@ -20,30 +20,30 @@ def finish_upload(heap: RemoteHeap) -> None:
 
 def make_program() -> tuple[RemoteHeap, LEDProgram]:
     heap = RemoteHeap(7200)
-    return heap, LEDProgram(heap, bitmap_led_program(), BITMAP_RENDERER, 450)
+    return heap, LEDProgram(heap, key_led_program(), KEY_RENDERER, 48)
 
 
 def pixels_in(heap: RemoteHeap, program: LEDProgram) -> bytes:
-    return heap.target[len(program.code) : len(program.code) + 450]
+    return heap.target[len(program.code) : len(program.code) + 48]
 
 
 def test_challenge_waits_for_complete_upload_and_ack():
     heap, program = make_program()
-    pixels = bytes([31, 0]) * 225
+    pixels = bytes([31, 0]) * 24
     assert program.set_frame(pixels)
     assert program.advance(0) is None
     while heap.send_changes(1) is not None:
         pass
     assert heap.in_flight_count > 0
     assert program.advance(1) is None
-    assert pixels_in(heap, program) == bytes(450)
+    assert pixels_in(heap, program) == bytes(48)
     finish_upload(heap)
     query = program.advance(2)
     assert query is not None
-    assert query[:2] == (RENDERER_READY_MARKER, BITMAP_RENDERER)
+    assert query[:2] == (RENDERER_READY_MARKER, KEY_RENDERER)
     assert 0 < query[2] <= 0x7FFFFFFF
     assert not program.ready
-    assert pixels_in(heap, program) == bytes(450)
+    assert pixels_in(heap, program) == bytes(48)
     program.on_ready(query)
     assert program.ready
     assert pixels_in(heap, program) == pixels
@@ -51,14 +51,14 @@ def test_challenge_waits_for_complete_upload_and_ack():
 
 def test_startup_coalesces_frames_and_rejects_unrelated_events():
     heap, program = make_program()
-    assert program.set_frame(bytes([31, 0]) * 225)
-    latest = bytes([0, 248]) * 225
+    assert program.set_frame(bytes([31, 0]) * 24)
+    latest = bytes([0, 248]) * 24
     assert program.set_frame(latest)
     assert not program.set_frame(b"invalid")
     finish_upload(heap)
     query = program.advance(0)
     assert query is not None
-    for reply in [(0, query[1], query[2]), (query[0], 2, query[2]), (query[0], query[1], 0)]:
+    for reply in [(0, query[1], query[2]), (query[0], 1, query[2]), (query[0], query[1], 0)]:
         program.on_ready(reply)
         assert not program.ready
     program.on_ready(query)
@@ -84,10 +84,10 @@ def test_live_frames_and_duplicate_replies_do_not_reload_or_erase_pixels():
     query = program.advance(0)
     assert query is not None
     program.on_ready(query)
-    assert program.set_frame(bytes([255]) * 450)
+    assert program.set_frame(bytes([255]) * 48)
     finish_upload(heap)
     program.on_ready(query)
-    assert pixels_in(heap, program) == bytes([255]) * 450
+    assert pixels_in(heap, program) == bytes([255]) * 48
     assert heap.target[: len(program.code)] == program.code
     assert not heap.is_dirty
     assert program.advance(10) is None
@@ -97,7 +97,7 @@ def test_live_frames_and_duplicate_replies_do_not_reload_or_erase_pixels():
 @pytest.mark.parametrize("phase", ["uploading", "querying", "live"])
 def test_state_loss_rechallenges_and_preserves_latest_pixels(full_reset, phase):
     heap, program = make_program()
-    latest = bytes([31, 0]) * 225
+    latest = bytes([31, 0]) * 24
     program.set_frame(latest)
     old_query = None
     if phase != "uploading":
@@ -116,7 +116,7 @@ def test_state_loss_rechallenges_and_preserves_latest_pixels(full_reset, phase):
         heap.reset_device_state()
     assert program.advance(1) is None
     assert not program.ready
-    assert pixels_in(heap, program) == bytes(450)
+    assert pixels_in(heap, program) == bytes(48)
     assert heap.target[: len(program.code)] == program.code
     if old_query:
         program.on_ready(old_query)
@@ -142,9 +142,9 @@ def test_event_and_frame_entrypoints_detect_reset_before_using_readiness():
     heap.reset_device_state()
     program.on_ready(query)
     assert not program.ready
-    assert pixels_in(heap, program) == bytes(450)
-    program.set_frame(bytes([255]) * 450)
-    assert pixels_in(heap, program) == bytes(450)
+    assert pixels_in(heap, program) == bytes(48)
+    program.set_frame(bytes([255]) * 48)
+    assert pixels_in(heap, program) == bytes(48)
 
 
 def test_unknown_ack_invalidates_outstanding_challenge():

--- a/tests/littlefoot/test_assembler.py
+++ b/tests/littlefoot/test_assembler.py
@@ -191,6 +191,55 @@ class TestAssemblerOpcodes:
 
 
 class TestAssemblerLabels:
+    @pytest.mark.parametrize("instruction", ["jump", "jump_if_true", "jump_if_false", "call"])
+    @pytest.mark.parametrize("function_count", [1, 2])
+    def test_forward_target_is_program_address(self, instruction, function_count):
+        asm = BytecodeAssembler()
+        asm.begin_function("test/v")
+        getattr(asm, instruction)("end")
+        asm.push0()
+        asm.label("end")
+        asm.push8(42)
+        asm.ret_void()
+        if function_count == 2:
+            asm.begin_function("other/v")
+            asm.ret_void()
+
+        program = asm.build()
+        entry = struct.unpack_from("<H", program, 12)[0]
+        target = struct.unpack_from("<H", program, entry + 1)[0]
+        # The VM resolves jumps from programBase, including the header and table.
+        assert target == entry + 4
+        assert program[target : target + 2] == bytes([Op.PUSH_8, 42])
+        assert asm.build() == program
+
+    def test_backward_target_matches_function_entry(self):
+        asm = BytecodeAssembler()
+        asm.begin_function("test/v")
+        asm.label("top")
+        asm.push0()
+        asm.jump("top")
+
+        program = asm.build()
+        entry = struct.unpack_from("<H", program, 12)[0]
+        target = struct.unpack_from("<H", program, entry + 2)[0]
+        assert target == entry
+
+    def test_rebuild_relocates_labels_after_function_table_grows(self):
+        asm = BytecodeAssembler()
+        asm.begin_function("test/v")
+        asm.label("top")
+        asm.jump("top")
+        first = asm.build()
+        asm.begin_function("other/v")
+        asm.ret_void()
+        second = asm.build()
+
+        first_entry = struct.unpack_from("<H", first, 12)[0]
+        second_entry = struct.unpack_from("<H", second, 12)[0]
+        assert second_entry == first_entry + 4
+        assert struct.unpack_from("<H", second, second_entry + 1)[0] == second_entry
+
     def test_forward_jump(self):
         asm = BytecodeAssembler()
         asm.begin_function("test/v")

--- a/tests/littlefoot/test_keys.py
+++ b/tests/littlefoot/test_keys.py
@@ -7,19 +7,15 @@ import struct
 from blocksd.littlefoot.assembler import compute_function_id, compute_program_checksum
 from blocksd.littlefoot.keys import KEY_COUNT, KEY_HEAP_SIZE, key_led_program, key_led_program_size
 
-# Upstream Runner executes initialise with (touch=true, lighting=false), then
-# disables the status overlay. Message callbacks echo matching challenge nonces;
-# repaint draws each RGB565 key once.
+# Upstream Runner verifies setLocalConfig(36, 100) during initialise and each
+# matching readiness challenge, including unchanged-code reuploads. Invalid
+# challenges and repaint never write config; touch=true/lighting=false and
+# every RGB565 pixel remain unchanged across black, white, and varied frames.
 _VERIFIED_PROGRAM = bytes.fromhex(
-    "8ca28200030000003000648c16008d6f"
-    "21000bea61000b078e7e0b0c07a38105"
-    "000b100d182436035e00100d10220b18"
-    "020d0518030d0b20400d032d0d061804"
-    "0d0520400d022d0d051805400d032d0e"
-    "ff0007833f070bc2080c200122000805"
-    "0018010f44454c422402800018020d02"
-    "2402800018030d020f44454c4207d2ce"
-    "0503"
+    "1a079000030000003000648c16008d6f28000bea68000d640d2407f6f80b078e7e0b0c07a38105000b100d1824"
+    "36036500100d10220b18020d0518030d0b20400d032d0d0618040d0520400d022d0d051805400d032d0eff0007"
+    "833f070bc2080c2001290008050018010f44454c4224028e0018020d0224028e000d640d2407f6f818030d020f"
+    "44454c4207d2ce0503"
 )
 
 

--- a/tests/littlefoot/test_keys.py
+++ b/tests/littlefoot/test_keys.py
@@ -1,0 +1,48 @@
+"""LUMI renderer vectors checked against the upstream LittleFoot VM."""
+
+from __future__ import annotations
+
+import struct
+
+from blocksd.littlefoot.assembler import compute_function_id, compute_program_checksum
+from blocksd.littlefoot.keys import KEY_COUNT, KEY_HEAP_SIZE, key_led_program, key_led_program_size
+
+# Upstream Runner executes initialise with (touch=true, lighting=false), then
+# disables the status overlay. Message callbacks echo matching challenge nonces;
+# repaint draws each RGB565 key once.
+_VERIFIED_PROGRAM = bytes.fromhex(
+    "8ca28200030000003000648c16008d6f"
+    "21000bea61000b078e7e0b0c07a38105"
+    "000b100d182436035e00100d10220b18"
+    "020d0518030d0b20400d032d0d061804"
+    "0d0520400d022d0d051805400d032d0e"
+    "ff0007833f070bc2080c200122000805"
+    "0018010f44454c422402800018020d02"
+    "2402800018030d020f44454c4207d2ce"
+    "0503"
+)
+
+
+def test_matches_program_executed_by_upstream_vm():
+    assert key_led_program() == _VERIFIED_PROGRAM
+
+
+def test_has_initialise_repaint_and_message_callbacks():
+    program = key_led_program()
+    assert struct.unpack_from("<H", program, 4)[0] == 3
+    assert struct.unpack_from("<h", program, 10)[0] == compute_function_id("initialise/v")
+    assert struct.unpack_from("<h", program, 14)[0] == compute_function_id("repaint/v")
+    assert struct.unpack_from("<h", program, 18)[0] == compute_function_id("handleMessage/viii")
+
+
+def test_pixel_heap_follows_program_and_fits_all_keys():
+    program = key_led_program()
+    assert KEY_COUNT == 24
+    assert KEY_HEAP_SIZE == 48
+    assert struct.unpack_from("<H", program, 8)[0] == KEY_HEAP_SIZE
+    assert struct.unpack_from("<H", program, 2)[0] == key_led_program_size() == len(program)
+
+
+def test_program_checksum_is_valid():
+    program = key_led_program()
+    assert struct.unpack_from("<H", program)[0] == compute_program_checksum(bytearray(program))

--- a/tests/littlefoot/test_programs.py
+++ b/tests/littlefoot/test_programs.py
@@ -22,10 +22,12 @@ class TestBitmapLEDProgram:
         size = struct.unpack_from("<H", program, 2)[0]
         assert size == len(program)
 
-    def test_one_function(self):
+    def test_initialise_repaint_and_message_callbacks(self):
         program = bitmap_led_program()
         num_funcs = struct.unpack_from("<H", program, 4)[0]
-        assert num_funcs == 1
+        assert num_funcs == 3
+        assert struct.unpack_from("<h", program, 10)[0] == compute_function_id("initialise/v")
+        assert struct.unpack_from("<h", program, 18)[0] == compute_function_id("handleMessage/viii")
 
     def test_heap_size_450(self):
         """15x15 grid x 2 bytes per pixel = 450."""
@@ -34,9 +36,9 @@ class TestBitmapLEDProgram:
         assert heap_size == 450
 
     def test_function_is_repaint(self):
-        """The single function should have the repaint FunctionID."""
+        """The second function exposes the repaint callback."""
         program = bitmap_led_program()
-        func_id = struct.unpack_from("<h", program, 10)[0]
+        func_id = struct.unpack_from("<h", program, 14)[0]
         expected = compute_function_id("repaint/v")
         assert func_id == expected
 
@@ -55,3 +57,23 @@ class TestBitmapLEDProgram:
     def test_reasonable_size(self):
         """Should be compact — under 200 bytes for such a simple program."""
         assert bitmap_led_program_size() < 200
+
+
+# Executed by the unchanged upstream VM: matching challenge nonces echoed,
+# every RGB565 pixel painted once per repaint, and status overlay disabled.
+_VERIFIED_PROGRAM = bytes.fromhex(
+    "1de8910003000000c201648c16008d6f"
+    "1c000bea72000b078e7e05000b100d0f"
+    "2436036f000b100d0f24360369001018"
+    "020d0f22200d1022180218020d051803"
+    "0d0b20400d032d0d0618040d0520400d"
+    "022d0d051805400d032d0eff0007833f"
+    "070bc2080c20012600080c20011d0008"
+    "050018010f44454c4224028f0018020c"
+    "24028f0018030c0f44454c4207d2ce05"
+    "03"
+)
+
+
+def test_matches_program_executed_by_upstream_vm():
+    assert bitmap_led_program() == _VERIFIED_PROGRAM

--- a/tests/littlefoot/test_programs.py
+++ b/tests/littlefoot/test_programs.py
@@ -29,11 +29,11 @@ class TestBitmapLEDProgram:
         assert struct.unpack_from("<h", program, 10)[0] == compute_function_id("initialise/v")
         assert struct.unpack_from("<h", program, 18)[0] == compute_function_id("handleMessage/viii")
 
-    def test_heap_size_450(self):
-        """15x15 grid x 2 bytes per pixel = 450."""
+    def test_heap_size_two_banks(self):
+        """Two 15x15 RGB565 banks consume 900 bytes."""
         program = bitmap_led_program()
         heap_size = struct.unpack_from("<H", program, 8)[0]
-        assert heap_size == 450
+        assert heap_size == 900
 
     def test_function_is_repaint(self):
         """The second function exposes the repaint callback."""
@@ -55,23 +55,24 @@ class TestBitmapLEDProgram:
         assert bitmap_led_program() is bitmap_led_program()
 
     def test_reasonable_size(self):
-        """Should be compact — under 200 bytes for such a simple program."""
-        assert bitmap_led_program_size() < 200
+        """Program and both pixel banks fit the 7200-byte device memory."""
+        assert bitmap_led_program_size() + 900 <= 7200
 
 
-# Executed by the unchanged upstream VM: matching challenge nonces echoed,
-# every RGB565 pixel painted once per repaint, and status overlay disabled.
+# Executed by the upstream VM: partial inactive-bank writes stay invisible,
+# identities remain idempotent, and presentation ACKs follow all 225 draws.
 _VERIFIED_PROGRAM = bytes.fromhex(
-    "1de8910003000000c201648c16008d6f"
-    "1c000bea72000b078e7e05000b100d0f"
-    "2436036f000b100d0f24360369001018"
-    "020d0f22200d1022180218020d051803"
-    "0d0b20400d032d0d0618040d0520400d"
-    "022d0d051805400d032d0eff0007833f"
-    "070bc2080c20012600080c20011d0008"
-    "050018010f44454c4224028f0018020c"
-    "24028f0018030c0f44454c4207d2ce05"
-    "03"
+    "3186da01030006008403648c16008d6f1c000bead1000b078e7e05001c00001c05000b1d05001c03000338001c"
+    "02001d01001c03001d04001c01001c03000b1d030018010e100e220b100d0f2436039e000b100d0f2436039800"
+    "1018020d0f22200d1022180320180218020d0518030d0b20400d032d0d0618040d0520400d022d0d051805400d"
+    "032d0eff0007833f070bc2080c20015200080c20014900080818031c00002402cb00180203b90018030c0f4445"
+    "4c4207d2ce1003cb0010180418030f00414c422007d2ce08080808050018010f44454c4224020f0118020c2402"
+    "d80118030c243503d80118031c00002403090118031d00000b1d01000b1d02000b1d03000b1d04000c1d050005"
+    "0318010f00504c422403280118010f01504c4224037a0101d80118021c00002402cc0118030c243503d8011803"
+    "1c04002403580118031c0400240c2402d8011c01000b2403d8010160011c01000b2402d8011c0300036f011c03"
+    "0018042402d8010b1d020018031d0300050318021c00002402cc0118030c243503d80118031c04002403aa0118"
+    "031c0400240c2402d8011c01000c2403d80101b2011c01000c2402d8011c030003c1011c030018042402d8010c"
+    "1d020018031d03000503180318030f524e4c4207d2ce0503"
 )
 
 

--- a/tests/protocol/test_builder.py
+++ b/tests/protocol/test_builder.py
@@ -41,3 +41,18 @@ class TestHostPacketBuilder:
         end = build_end_api_mode(0)
         assert ping != begin
         assert begin != end
+
+
+class TestProgramEvents:
+    def test_challenge_matches_upstream_cpp_packing(self) -> None:
+        from blocksd.protocol.builder import build_program_event
+
+        # Golden vector produced by the upstream Packed7BitArrayBuilder.
+        expected = bytes.fromhex("f0002110771603440a311224000000007e7f7f7f0f45f7")
+        assert build_program_event(22, (0x424C4544, 2, 0x7FFFFFFF)) == expected
+
+    def test_signed_arguments_match_upstream_cpp_packing(self) -> None:
+        from blocksd.protocol.builder import build_program_event
+
+        expected = bytes.fromhex("f00021107716037f7f7f7f0f00000000000000001025f7")
+        assert build_program_event(22, (-1, 0, -2147483648)) == expected

--- a/tests/protocol/test_builder_config.py
+++ b/tests/protocol/test_builder_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from blocksd.protocol.builder import (
     HostPacketBuilder,
     build_config_request,
@@ -32,6 +34,19 @@ class TestBuildConfigSet:
 
 
 class TestBuildConfigRequest:
+    @pytest.mark.parametrize(
+        ("item", "expected"),
+        [
+            (0, "f00021107716100100000000000011f7"),
+            (36, "f00021107716100100000000480069f7"),
+            (255, "f000211077161001000000007e030ef7"),
+        ],
+    )
+    def test_matches_upstream_reserved_address_field(self, item, expected):
+        # SDK addRequestMessage writes 32 zero bits before the 8-bit item.
+        # Vectors include the footer from the unchanged C++ bit-packing helper.
+        assert build_config_request(22, item) == bytes.fromhex(expected)
+
     def test_valid_sysex(self):
         packet = build_config_request(0, 10)
         assert _valid_sysex(packet)

--- a/tests/protocol/test_data_change.py
+++ b/tests/protocol/test_data_change.py
@@ -11,6 +11,7 @@ from blocksd.protocol.data_change import (
     build_data_change_packet,
     compute_diff,
     encode_regions,
+    encode_regions_limited,
 )
 from blocksd.protocol.packing import Packed7BitReader, Packed7BitWriter
 
@@ -430,3 +431,20 @@ class TestBuildDataChangePacket:
         # Should contain skip and set commands
         cmd_types = [c[0] for c in cmds]
         assert any(t.startswith(("skip", "set")) for t in cmd_types)
+
+
+@pytest.mark.parametrize("skip_count", [1, 15, 16, 255, 256, 7200])
+def test_limited_encoder_reserves_end_marker_before_skip(skip_count):
+    writer = Packed7BitWriter(8)
+    encoder = DataChangeEncoder(writer)
+    target = b"abcd" + bytes(skip_count) + b"z"
+    result = bytearray(len(target))
+    regions = [
+        DiffRegion(False, 0, 4),
+        DiffRegion(True, 4, skip_count),
+        DiffRegion(False, 4 + skip_count, 1),
+    ]
+    assert not encode_regions_limited(encoder, regions, target, result)
+    encoder.end(is_last=False)
+    assert decode_commands(writer) == [("set_sequence", b"abcd"), ("end_of_packet",)]
+    assert result == b"abcd" + bytes(skip_count + 1)

--- a/tests/protocol/test_remote_heap.py
+++ b/tests/protocol/test_remote_heap.py
@@ -501,3 +501,20 @@ class TestIntegration:
         assert len(packets) > 1
         assert _decode_end_marker(packets[0]) == "end_of_packet"
         assert _decode_end_marker(packets[-1]) == "end_of_changes"
+
+
+def test_generation_changes_only_when_confirmed_state_is_invalidated():
+    heap = RemoteHeap(7200)
+    assert heap.generation == 0
+    heap.set_bytes(0, b"program")
+    assert heap.send_changes(0) is not None
+    assert heap.handle_ack((heap.packet_index - 1) & 0x3FF)
+    assert heap.generation == 0
+    assert not heap.handle_ack((heap.packet_index - 1) & 0x3FF)
+    assert heap.generation == 0
+    assert not heap.handle_ack(99)
+    assert heap.generation == 1
+    heap.reset_device_state()
+    assert heap.generation == 2
+    heap.reset()
+    assert heap.generation == 3

--- a/tests/protocol/test_remote_heap_streaming.py
+++ b/tests/protocol/test_remote_heap_streaming.py
@@ -1,0 +1,163 @@
+"""Decode real heap packets while frames arrive faster than a transfer completes."""
+
+from __future__ import annotations
+
+import colorsys
+from collections import deque
+
+import pytest
+
+from blocksd.led.bitmap import Color
+from blocksd.littlefoot.programs import bitmap_led_program
+from blocksd.protocol.constants import BitSize, DataChangeCommand
+from blocksd.protocol.packing import Packed7BitReader
+from blocksd.protocol.remote_heap import RemoteHeap
+
+
+def apply_packet(device: bytearray, packet: bytes) -> tuple[int, bool]:
+    """Apply the wire command stream independently of RemoteHeap's shadow state."""
+    assert len(packet) <= 200
+    reader = Packed7BitReader(packet[6:-2])
+    reader.read_bits(BitSize.MESSAGE_TYPE)
+    index = reader.read_bits(BitSize.PACKET_INDEX)
+    cursor = 0
+    last_value = None
+    while reader.remaining_bits >= BitSize.DATA_CHANGE_COMMAND:
+        command = reader.read_bits(BitSize.DATA_CHANGE_COMMAND)
+        if command in (DataChangeCommand.END_OF_PACKET, DataChangeCommand.END_OF_CHANGES):
+            return index, command == DataChangeCommand.END_OF_CHANGES
+        if command in (DataChangeCommand.SKIP_BYTES_FEW, DataChangeCommand.SKIP_BYTES_MANY):
+            bits = (
+                BitSize.BYTE_COUNT_FEW
+                if command == DataChangeCommand.SKIP_BYTES_FEW
+                else BitSize.BYTE_COUNT_MANY
+            )
+            cursor += reader.read_bits(bits)
+            continue
+        if command == DataChangeCommand.SET_SEQUENCE_OF_BYTES:
+            values = bytearray()
+            while True:
+                last_value = reader.read_bits(BitSize.BYTE_VALUE)
+                values.append(last_value)
+                if not reader.read_bits(BitSize.BYTE_SEQUENCE_CONTINUES):
+                    break
+        else:
+            bits = (
+                BitSize.BYTE_COUNT_MANY
+                if command == DataChangeCommand.SET_MANY_BYTES_WITH_VALUE
+                else BitSize.BYTE_COUNT_FEW
+            )
+            count = reader.read_bits(bits)
+            if command != DataChangeCommand.SET_FEW_BYTES_WITH_LAST_VALUE:
+                last_value = reader.read_bits(BitSize.BYTE_VALUE)
+            assert last_value is not None
+            values = bytearray([last_value] * count)
+        assert cursor + len(values) <= len(device)
+        device[cursor : cursor + len(values)] = values
+        cursor += len(values)
+    raise AssertionError("missing packet end marker")
+
+
+def drain(heap: RemoteHeap, device: bytearray) -> list[bytes]:
+    """Send and acknowledge every remaining packet, retaining completed states."""
+    completed = []
+    while heap.is_dirty:
+        packet = heap.send_changes(1, now=0)
+        assert packet is not None
+        index, final = apply_packet(device, packet)
+        assert heap.handle_ack(index)
+        if final:
+            completed.append(bytes(device))
+    return completed
+
+
+@pytest.mark.parametrize("ack_ms", [20, 40, 120])
+def test_continuous_rainbow_updates_complete_all_rows(ack_ms: int):
+    code = bitmap_led_program()
+    heap = RemoteHeap(7200)
+    device = bytearray([0xA5] * heap.size)
+    heap.set_bytes(0, code)
+    drain(heap, device)
+    assert device == code + bytes(heap.size - len(code))
+    pending: deque[bytes] = deque()
+    frames: set[bytes] = set()
+    row_updates = [0] * 15
+    completed = 0
+
+    def flush(now: float) -> None:
+        while (packet := heap.send_changes(1, now)) is not None:
+            pending.append(packet)
+
+    def acknowledge(now: float) -> None:
+        nonlocal completed
+        before = device[:]
+        index, final = apply_packet(device, pending.popleft())
+        assert heap.handle_ack(index)
+        for row in range(15):
+            start = len(code) + row * 30
+            if device[start : start + 30] != before[start : start + 30]:
+                row_updates[row] += 1
+        if final:
+            assert bytes(device[len(code) : len(code) + 450]) in frames
+            completed += 1
+        flush(now)
+
+    for ms in range(0, 15000, 20):
+        if ms % 40 == 0:
+            row = bytearray()
+            for x in range(15):
+                rgb = colorsys.hsv_to_rgb((x / 15 + ms / 6000) % 1, 1, 0.75)
+                row.extend(Color(*(round(value * 255) for value in rgb)).to_rgb565())
+            pixels = bytes(row * 15)
+            frames.add(pixels)
+            heap.set_bytes(len(code), pixels)
+            flush(ms / 1000)
+        if ms % ack_ms == 0 and pending:
+            acknowledge(ms / 1000)
+
+    # Every row progresses during the stream, before the final drain.
+    assert min(row_updates) >= 10, row_updates
+    assert completed >= 10
+    for _ in range(100):
+        if not pending:
+            break
+        acknowledge(15)
+    assert not pending
+    assert not heap.is_dirty
+    assert device == heap.target
+
+
+def test_reverting_target_finishes_snapshot_then_restores_latest():
+    baseline = bytes(i % 251 + 1 for i in range(600))
+    changed = bytes(value ^ 0x5A for value in baseline)
+    heap = RemoteHeap(len(baseline))
+    device = bytearray(len(baseline))
+    heap.set_bytes(0, baseline)
+    drain(heap, device)
+    heap.set_bytes(0, changed)
+    first = heap.send_changes(1, now=0)
+    assert first is not None
+    index, final = apply_packet(device, first)
+    assert not final
+    assert heap.handle_ack(index)
+    heap.set_bytes(0, baseline)
+    completed = drain(heap, device)
+    assert completed == [changed, baseline]
+    assert device == baseline
+
+
+@pytest.mark.parametrize("reset", ["reset", "reset_device_state", "unknown_ack"])
+def test_reset_discards_partial_snapshot(reset: str):
+    heap = RemoteHeap(600)
+    old = bytes(i % 251 + 1 for i in range(heap.size))
+    newest = bytes(value ^ 0xFF for value in old)
+    heap.set_bytes(0, old)
+    assert heap.send_changes(1, now=0) is not None
+    if reset == "unknown_ack":
+        assert not heap.handle_ack(99)
+    else:
+        getattr(heap, reset)()
+    heap.set_bytes(0, newest)
+    device = bytearray([0xA5] * heap.size)
+    assert drain(heap, device) == [newest]
+    assert device == newest

--- a/tests/test_api_events.py
+++ b/tests/test_api_events.py
@@ -196,9 +196,15 @@ class TestDeviceSerialization:
         assert d["block_type"] == "lumi_keys"
         assert d["grid_width"] == 0
         assert d["grid_height"] == 0
+        assert d["key_count"] == 24
         assert d["battery_level"] == 50
         assert d["battery_charging"] is True
         assert d["firmware_version"] == "1.2.3"
+
+    def test_lightpad_has_no_physical_keys(self, lightpad: DeviceInfo) -> None:
+        d = _device_to_dict(lightpad)
+        assert d["key_count"] == 0
+        assert d["grid_width"] == d["grid_height"] == 15
 
     def test_block_type_mapping(self) -> None:
         assert _block_type_to_api(BlockType.LIGHTPAD) == "lightpad"

--- a/tests/test_api_key_frames.py
+++ b/tests/test_api_key_frames.py
@@ -1,0 +1,118 @@
+"""Physical key frames stay separate from Lightpad bitmap frames."""
+
+import asyncio
+import base64
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from blocksd.api.server import ApiServer, WebServer
+from blocksd.device.models import BlockType, DeviceInfo
+
+
+@pytest.fixture(params=[ApiServer, WebServer])
+def key_api(request):
+    manager = Mock()
+    manager.find_device.return_value = DeviceInfo(
+        uid=7, topology_index=1, serial="LKB000", block_type=BlockType.LUMI_KEYS
+    )
+    manager.set_key_led_data.return_value = True
+    return request.param(manager), manager
+
+
+def send(server, message):
+    response, subscription = server._handle_json(
+        json.dumps(message).encode(), asyncio.Queue(), None
+    )
+    assert subscription is None
+    return response
+
+
+def test_key_frame_preserves_physical_order_and_request_id(key_api):
+    server, manager = key_api
+    pixels = bytes([255, 0, 0, 0, 255, 0, 0, 0, 255]) * 8
+    response = send(
+        server,
+        {"type": "key_frame", "uid": 7, "pixels": base64.b64encode(pixels).decode(), "id": 0},
+    )
+    assert response == {"type": "key_frame_ack", "uid": 7, "accepted": True, "id": 0}
+    manager.set_key_led_data.assert_called_once_with(7, bytes.fromhex("1f00e00700f8") * 8)
+    manager.set_led_data.assert_not_called()
+
+
+def test_key_frame_applies_existing_brightness(key_api):
+    server, manager = key_api
+    send(server, {"type": "brightness", "uid": 7, "value": 127.9})
+    response = send(
+        server,
+        {"type": "key_frame", "uid": 7, "pixels": base64.b64encode(b"\xff" * 72).decode()},
+    )
+    assert response["accepted"] is True
+    manager.set_key_led_data.assert_called_once_with(7, bytes.fromhex("ef7b") * 24)
+
+
+@pytest.mark.parametrize("uid", [None, True, "7", [], {}])
+def test_key_frame_rejects_invalid_uid_without_writes(key_api, uid):
+    server, manager = key_api
+    response = send(
+        server, {"type": "key_frame", "uid": uid, "pixels": base64.b64encode(bytes(72)).decode()}
+    )
+    assert response["type"] == "key_frame_ack"
+    assert response["accepted"] is False
+    manager.find_device.assert_not_called()
+    manager.set_key_led_data.assert_not_called()
+    manager.set_led_data.assert_not_called()
+
+
+@pytest.mark.parametrize("size", [0, 48, 71, 73, 675])
+def test_key_frame_rejects_wrong_frame_size_without_writes(key_api, size):
+    server, manager = key_api
+    response = send(
+        server, {"type": "key_frame", "uid": 7, "pixels": base64.b64encode(bytes(size)).decode()}
+    )
+    assert response["accepted"] is False
+    manager.set_key_led_data.assert_not_called()
+    manager.set_led_data.assert_not_called()
+
+
+@pytest.mark.parametrize("pixels", [None, [], {}, "!invalid-base64!"])
+def test_key_frame_rejects_invalid_encoding_without_writes(key_api, pixels):
+    server, manager = key_api
+    response = send(server, {"type": "key_frame", "uid": 7, "pixels": pixels})
+    assert response["accepted"] is False
+    manager.set_key_led_data.assert_not_called()
+    manager.set_led_data.assert_not_called()
+
+
+@pytest.mark.parametrize("block_type", [None, *[t for t in BlockType if t != BlockType.LUMI_KEYS]])
+def test_key_frame_rejects_missing_or_unsupported_device(key_api, block_type):
+    server, manager = key_api
+    manager.find_device.return_value = (
+        None
+        if block_type is None
+        else DeviceInfo(uid=7, topology_index=1, serial="OTHER", block_type=block_type)
+    )
+    response = send(
+        server, {"type": "key_frame", "uid": 7, "pixels": base64.b64encode(bytes(72)).decode()}
+    )
+    assert response["accepted"] is False
+    manager.set_key_led_data.assert_not_called()
+    manager.set_led_data.assert_not_called()
+
+
+def test_key_frame_reports_manager_rejection(key_api):
+    server, manager = key_api
+    manager.set_key_led_data.return_value = False
+    response = send(
+        server, {"type": "key_frame", "uid": 7, "pixels": base64.b64encode(bytes(72)).decode()}
+    )
+    assert response == {"type": "key_frame_ack", "uid": 7, "accepted": False}
+
+
+def test_discovery_exposes_key_count_without_bitmap_dimensions(key_api):
+    server, manager = key_api
+    manager.devices = [manager.find_device.return_value]
+    device = send(server, {"type": "discover"})["devices"][0]
+    assert device["key_count"] == 24
+    assert device["grid_width"] == device["grid_height"] == 0

--- a/tests/topology/test_device_group.py
+++ b/tests/topology/test_device_group.py
@@ -293,9 +293,15 @@ class TestACKHandling:
         uid = next(iter(group._devices))
         assert group.set_led_data(uid, grid.heap_data)
         # Program upload completes before the first pixel frame is released.
-        group._process_message(_build_ack_packet(0, counter=_decode_packet_index(conn.sent[-1])))
-        reader = Packed7BitReader(conn.sent[-1][6:-2])
-        assert reader.read_bits(7) == MessageFromHost.PROGRAM_EVENT
+        for _ in range(20):
+            reader = Packed7BitReader(conn.sent[-1][6:-2])
+            if reader.read_bits(7) == MessageFromHost.PROGRAM_EVENT:
+                break
+            group._process_message(
+                _build_ack_packet(0, counter=_decode_packet_index(conn.sent[-1]))
+            )
+        else:
+            raise AssertionError("program upload never reached its readiness challenge")
         query = (reader.read_bits(32), reader.read_bits(32), reader.read_bits(32))
         conn.sent.clear()
         group.on_program_event(0, 0, query)

--- a/tests/topology/test_device_group.py
+++ b/tests/topology/test_device_group.py
@@ -13,6 +13,7 @@ from blocksd.protocol.constants import (
     SERIAL_DUMP_RESPONSE_HEADER,
     BitSize,
     MessageFromDevice,
+    MessageFromHost,
 )
 from blocksd.protocol.packing import Packed7BitReader, Packed7BitWriter
 from blocksd.topology.device_group import (
@@ -291,6 +292,13 @@ class TestACKHandling:
         conn.sent.clear()
         uid = next(iter(group._devices))
         assert group.set_led_data(uid, grid.heap_data)
+        # Program upload completes before the first pixel frame is released.
+        group._process_message(_build_ack_packet(0, counter=_decode_packet_index(conn.sent[-1])))
+        reader = Packed7BitReader(conn.sent[-1][6:-2])
+        assert reader.read_bits(7) == MessageFromHost.PROGRAM_EVENT
+        query = (reader.read_bits(32), reader.read_bits(32), reader.read_bits(32))
+        conn.sent.clear()
+        group.on_program_event(0, 0, query)
         first_burst = list(conn.sent)
         assert len(first_burst) > 1
         heap = group.get_heap(uid)

--- a/tests/topology/test_receive_loop.py
+++ b/tests/topology/test_receive_loop.py
@@ -1,0 +1,181 @@
+"""MIDI reception runs independently of the device lifecycle timer."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+
+from blocksd.topology import device_group
+from blocksd.topology.device_group import TICK_INTERVAL, DeviceGroup, GroupState
+from tests.topology.test_device_group import _build_ack_packet
+
+
+class QueueTransport:
+    name = "Queued MIDI"
+
+    def __init__(self):
+        self.queue: asyncio.Queue[bytes | None] = asyncio.Queue()
+        self.is_open = True
+        self.close_calls = 0
+
+    def send(self, data):
+        return self.is_open
+
+    def drain(self):
+        messages = []
+        while not self.queue.empty():
+            if (message := self.queue.get_nowait()) is not None:
+                messages.append(message)
+        return messages
+
+    async def recv(self, timeout=None):
+        try:
+            return await asyncio.wait_for(self.queue.get(), timeout)
+        except TimeoutError:
+            return None
+
+    def close(self):
+        self.close_calls += 1
+        self.is_open = False
+
+
+class RecordingGroup(DeviceGroup):
+    def __init__(self, transport):
+        super().__init__(transport)
+        self.ticks = []
+        self.first_tick = asyncio.Event()
+        self.received = asyncio.Event()
+        self.acks = []
+        self.remove_calls = 0
+
+    def _lifecycle_timer(self, now):
+        self.ticks.append(now)
+        self.first_tick.set()
+
+    def on_packet_ack(self, device_index, counter):
+        self.acks.append((device_index, counter))
+        self.received.set()
+
+    def _remove_all_devices(self):
+        self.remove_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_ack_arriving_between_lifecycle_ticks_is_processed_immediately(monkeypatch):
+    # Widen the old sleeping window without tightening CI scheduling demands.
+    interval = 2.0
+    monkeypatch.setattr(device_group, "TICK_INTERVAL", interval)
+    transport = QueueTransport()
+    group = RecordingGroup(transport)
+    task = asyncio.create_task(group.run())
+    try:
+        await group.first_tick.wait()
+        await asyncio.sleep(0.02)
+        transport.queue.put_nowait(_build_ack_packet(0, counter=123))
+        await asyncio.wait_for(group.received.wait(), interval / 2)
+        assert group.acks == [(0, 123)]
+        assert len(group.ticks) == 1
+    finally:
+        task.cancel()
+        await task
+    assert transport.close_calls == group.remove_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_preloaded_receive_burst_preserves_timer_cadence_and_peer_progress(monkeypatch):
+    clock = SimpleNamespace(now=0.0)
+    monkeypatch.setattr(device_group, "time", SimpleNamespace(monotonic=lambda: clock.now))
+    packet = _build_ack_packet(0, counter=1)
+
+    class BurstTransport(QueueTransport):
+        async def recv(self, timeout=None):
+            # No suspension: model a transport with a preloaded receive queue.
+            clock.now += 0.003
+            if clock.now >= 0.7:
+                self.is_open = False
+                return None
+            return packet
+
+    transport = BurstTransport()
+    group = RecordingGroup(transport)
+    peer_turns = 0
+
+    async def peer():
+        nonlocal peer_turns
+        while transport.is_open:
+            peer_turns += 1
+            await asyncio.sleep(0)
+
+    await asyncio.gather(group.run(), peer())
+    assert len(group.acks) > 200
+    assert peer_turns > 200
+    assert len(group.ticks) == 4
+    for index, actual in enumerate(group.ticks):
+        assert abs(actual - index * TICK_INTERVAL) < 0.0031
+    assert transport.close_calls == group.remove_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_idle_receive_waits_until_lifecycle_deadline(monkeypatch):
+    clock = SimpleNamespace(now=0.0)
+    monkeypatch.setattr(device_group, "time", SimpleNamespace(monotonic=lambda: clock.now))
+    deadlines = []
+
+    class IdleTransport(QueueTransport):
+        async def recv(self, timeout=None):
+            assert timeout is not None and timeout > 0
+            deadlines.append(timeout)
+            clock.now += timeout
+            if len(deadlines) == 3:
+                self.is_open = False
+
+    transport = IdleTransport()
+    group = RecordingGroup(transport)
+    await group.run()
+    assert deadlines == pytest.approx([TICK_INTERVAL] * 3)
+    assert group.ticks == pytest.approx([0, TICK_INTERVAL, TICK_INTERVAL * 2])
+    assert transport.close_calls == group.remove_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_closing_transport_ends_receive_loop_and_cleans_up():
+    transport = QueueTransport()
+    group = RecordingGroup(transport)
+    task = asyncio.create_task(group.run())
+    await group.first_tick.wait()
+    transport.is_open = False
+    transport.queue.put_nowait(None)
+    await asyncio.wait_for(task, 1)
+    assert transport.close_calls == group.remove_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_receive_error_still_removes_devices_and_closes_transport():
+    class BrokenTransport(QueueTransport):
+        async def recv(self, timeout=None):
+            raise OSError("transport failed")
+
+    transport = BrokenTransport()
+    group = RecordingGroup(transport)
+    with pytest.raises(OSError, match="transport failed"):
+        await group.run()
+    assert transport.close_calls == group.remove_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_failed_lifecycle_does_not_start_another_receive():
+    class FailedGroup(RecordingGroup):
+        def _lifecycle_timer(self, now):
+            super()._lifecycle_timer(now)
+            self.state = GroupState.FAILED
+
+    class NoReceiveTransport(QueueTransport):
+        async def recv(self, timeout=None):
+            raise AssertionError("failed lifecycle must not receive again")
+
+    transport = NoReceiveTransport()
+    group = FailedGroup(transport)
+    await group.run()
+    assert transport.close_calls == group.remove_calls == 1


### PR DESCRIPTION
Lightpad frames could be accepted without producing the requested colors, and LUMI had no per-key lighting API. This change restores device-side rendering for Lightpad grids and adds individual colors for all 24 LUMI keys.

The assembler relocates jump targets to their position in the complete program. Both renderers disable the firmware status overlay. The daemon uploads code separately from pixels, waits for the complete upload acknowledgement, then challenges the running renderer with a fresh nonce. Heap-state loss restarts that handshake, including when identical program bytes survive without another initialise callback.

LUMI exposes JSON `key_frame` (72 RGB888 bytes), discovery `key_count = 24`, and `blocksd led keys [rainbow|HEX]`. Firmware 1.3.0 or newer is required. The renderer enables default musical key handling while replacing key lighting. Factory programs remain active until a lighting request arrives; the existing Lightpad binary API stays compatible.

## 🛠️ Complete animation frames

Continuous input previously replaced unfinished heap targets, repeatedly updating the prefix while starving lower Lightpad rows. Each multipart transfer now finishes an immutable snapshot while newer desired frames coalesce separately. The encoder also reserves capacity for skip commands and its end marker.

Lightpad uses two 450-byte pixel banks. The host uploads into the inactive bank, then requests presentation after its heap packets are acknowledged. The renderer latches one bank for the entire repaint and acknowledges only after all 225 pixel writes. Session, sequence, and bank checks prevent stale replies from releasing a bank; retries and identical-code reconnects preserve ownership. Startup and recovery may blank the display during resynchronisation.

MIDI reception is independent of the 200 ms lifecycle timer. Incoming acknowledgements are processed immediately, while absolute timer deadlines and cooperative yielding preserve keepalives and other tasks during continuous traffic.

## 🧪 Validation

- Full `just check` passes on the final head: **625 Python tests**, Ruff, ty, dashboard checks, docs build, packaging, and fresh installed-wheel validation.
- Independent decoded-wire tests verify complete snapshots, final convergence, resets, and cumulative acknowledgements, including 2,194 randomized packets.
- An independently rebuilt vendor VM passes **92 repaints / 20,700 pixel writes**, including partial inactive-bank uploads, stale messages, retries, identical-code recovery, and presentation requests injected halfway through repaint.
- Independent native-thread callbacks through the real MIDI connection abstraction arrive between lifecycle ticks in under 2 ms. The original loop reproduced a 180 ms queue delay.
- On LUMI 1.3.9 over USB and Lightpad M 1.1.0 over DNA, a 15-second native Hypercolor sweep accepted **376 frames per device**. Lightpad acknowledged **113 complete repaints**, approximately **7.53 repaints/sec** between the first and last acknowledgement, up from **1.46/sec** before the receive-loop fix. These are logical repaint measurements, not physical LED scan timing.

The hardware owner confirmed whole-pad animation after the snapshot fix. Final visual feedback on buffered alignment remains pending. Physical MIDI/MPE preservation, cable/power-loss recovery, and hardware operation on macOS remain unverified. The vendor VM verifies the musical-handler arguments; a live MIDI/MPE exercise is still needed.

The matching Rust bridge is in [Hypercolor #263](https://github.com/hyperb1iss/hypercolor/pull/263). Python retains ownership of MIDI and the device protocol; Hypercolor supplies effects and spatial mapping.


The LUMI renderer now claims hardware brightness at 100% during initialization and validated readiness challenges, including reconnects with unchanged code. Host RGB/API brightness still controls dimming, and gamma is unchanged. Hardware readback confirmed brightness 100 in its 0–100 range. Config requests also include the SDK-required 32-bit reserved address field; three upstream C++ wire vectors cover the correction. Independent native-VM checks verified brightness calls, readiness ordering, unchanged musical-handler arguments, and black/white/patterned key frames.
