### PR TITLE
fix(config): correct ROLI system setting IDs and labels

### DIFF
--- a/docs/architecture/modules.md
+++ b/docs/architecture/modules.md
@@ -56,7 +56,7 @@ Maps serial number prefixes to `BlockType` values. Used during device identifica
 
 ### `config_ids.py`
 
-Known device configuration item IDs and their human-readable descriptions. Used by the `blocksd config list` command and for config sync.
+SDK system configuration IDs and their names, displayed by `blocksd config list`. Config synchronization and API requests use numeric IDs directly.
 
 ## topology/
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -118,6 +118,23 @@ Show all known configuration item IDs and their descriptions.
 blocksd config list
 ```
 
+The list follows the system IDs in the [ROLI BLOCKS SDK](https://github.com/WeAreROLI/roli_blocks_basics/blob/212ba4e237638b9ae8c2a4f76dd2070110392031/blocks/roli_BlockConfigId.h). An ID in this list does not establish that your device or its current program supports it. Use device-reported values and ranges.
+
+Earlier versions mislabeled several IDs. Update scripts that imported the Python enum or selected numeric IDs from the old list:
+
+| Setting                    | Correct ID | Earlier mapping                                             |
+| -------------------------- | ---------- | ----------------------------------------------------------- |
+| Glide sensitivity          | 11         | 12                                                          |
+| Slide sensitivity          | 12         | 11                                                          |
+| MIDI mode (`midi_use_mpe`) | 2          | `midi_channel_mode` labeled ID 7, which is slide mode       |
+| Mode                       | 20         | Labeled `grid_size`                                         |
+| Chord                      | 24         | Labeled `colour_preset`                                     |
+| MPE zone                   | 40         | 30, which is X tracking mode                                |
+| MIDI start channel         | 0          | `mpe_channel_start` labeled ID 31, which is Y tracking mode |
+| MIDI end channel           | 1          | `mpe_channel_end` labeled ID 32, which is Z tracking mode   |
+
+The incorrect enum names were removed. Numeric config requests still send the supplied ID unchanged. Global key color, root key color, and hardware brightness use IDs 34, 35, and 36. The SDK describes hardware brightness on a 0 to 100 scale; the daemon's frame brightness control uses 0 to 255 and is a separate setting.
+
 ### `blocksd config get <id>`
 
 Read a configuration value from the device.

--- a/src/blocksd/device/config_ids.py
+++ b/src/blocksd/device/config_ids.py
@@ -1,31 +1,46 @@
-"""Block configuration item IDs — indices used in config get/set messages."""
+"""System configuration IDs from the ROLI BLOCKS SDK's roli_BlockConfigId.h."""
 
 from enum import IntEnum
 
 
 class BlockConfigId(IntEnum):
-    """Known configuration items for ROLI Blocks."""
+    """SDK system IDs; availability and ranges depend on the device program."""
 
-    VELOCITY_SENSITIVITY = 10
-    SLIDE_SENSITIVITY = 11
-    SLIDE_CC = 6
-    GLIDE_SENSITIVITY = 12
-    PRESSURE_SENSITIVITY = 13
-    LIFT_SENSITIVITY = 14
+    MIDI_START_CHANNEL = 0
+    MIDI_END_CHANNEL = 1
+    MIDI_USE_MPE = 2
     PITCHBEND_RANGE = 3
     OCTAVE = 4
     TRANSPOSE = 5
-    MIDI_CHANNEL_MODE = 7
+    SLIDE_CC = 6
+    SLIDE_MODE = 7
+    OCTAVE_TOPOLOGY = 8
+    MIDI_CHANNEL_RANGE = 9
+    VELOCITY_SENSITIVITY = 10
+    GLIDE_SENSITIVITY = 11
+    SLIDE_SENSITIVITY = 12
+    PRESSURE_SENSITIVITY = 13
+    LIFT_SENSITIVITY = 14
     FIXED_VELOCITY = 15
+    FIXED_VELOCITY_VALUE = 16
+    PIANO_MODE = 17
     GLIDE_LOCK_RATE = 18
     GLIDE_LOCK_ENABLED = 19
-    GRID_SIZE = 20
+    MODE = 20
+    VOLUME = 21
     SCALE = 22
     HIDE_MODE = 23
-    COLOUR_PRESET = 24
-    MPE_ZONE = 30
-    MPE_CHANNEL_START = 31
-    MPE_CHANNEL_END = 32
+    CHORD = 24
+    ARP_PATTERN = 25
+    TEMPO = 26
+    KEY = 27
+    AUTO_TRANSPOSE_TO_KEY = 28
+    X_TRACKING_MODE = 30
+    Y_TRACKING_MODE = 31
+    Z_TRACKING_MODE = 32
     GAMMA_CORRECTION = 33
-    PIANO_MODE = 17
-    FIXED_VELOCITY_VALUE = 16
+    GLOBAL_KEY_COLOUR = 34
+    ROOT_KEY_COLOUR = 35
+    BRIGHTNESS = 36
+    MPE_ZONE = 40
+    KEY_PITCH_BEND_AMOUNT = 41

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -27,7 +27,11 @@ class TestConfigSubcommands:
         result = runner.invoke(app, ["config", "list"])
         assert result.exit_code == 0
         assert "velocity_sensitivity" in result.output
-        assert "midi_channel_mode" in result.output
+        assert "slide_mode" in result.output
+        assert "x_tracking_mode" in result.output
+        assert "global_key_colour" in result.output
+        assert "midi_channel_mode" not in result.output
+        assert "colour_preset" not in result.output
 
     def test_get_missing_item(self):
         result = runner.invoke(app, ["config", "get"])

--- a/tests/device/test_config_ids.py
+++ b/tests/device/test_config_ids.py
@@ -1,0 +1,50 @@
+"""Wire IDs checked against ROLI's system configuration declarations.
+
+Reference: roli_blocks_basics at 212ba4e237638b9ae8c2a4f76dd2070110392031,
+blocks/roli_BlockConfigId.h and littlefoot/scripts/LittleFootLibrary/ConfigIds.littlefoot.
+"""
+
+import pytest
+
+from blocksd.device.config_ids import BlockConfigId
+
+
+@pytest.mark.parametrize(
+    ("name", "wire_id"),
+    [
+        ("MIDI_START_CHANNEL", 0),
+        ("MIDI_END_CHANNEL", 1),
+        ("MIDI_USE_MPE", 2),
+        ("SLIDE_MODE", 7),
+        ("GLIDE_SENSITIVITY", 11),
+        ("SLIDE_SENSITIVITY", 12),
+        ("MODE", 20),
+        ("CHORD", 24),
+        ("X_TRACKING_MODE", 30),
+        ("Y_TRACKING_MODE", 31),
+        ("Z_TRACKING_MODE", 32),
+        ("GLOBAL_KEY_COLOUR", 34),
+        ("ROOT_KEY_COLOUR", 35),
+        ("BRIGHTNESS", 36),
+        ("MPE_ZONE", 40),
+        ("KEY_PITCH_BEND_AMOUNT", 41),
+    ],
+)
+def test_system_setting_wire_id(name: str, wire_id: int):
+    assert BlockConfigId[name].value == wire_id
+    assert BlockConfigId(wire_id).name == name
+
+
+def test_system_ids_preserve_sdk_gaps_and_exclude_user_slots():
+    assert {item.value for item in BlockConfigId} == set(range(29)) | set(range(30, 37)) | {
+        40,
+        41,
+    }
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["MIDI_CHANNEL_MODE", "GRID_SIZE", "COLOUR_PRESET", "MPE_CHANNEL_START", "MPE_CHANNEL_END"],
+)
+def test_misleading_names_are_not_compatibility_aliases(name: str):
+    assert name not in BlockConfigId.__members__


### PR DESCRIPTION
Several configuration labels point at unrelated settings: glide and slide sensitivities are swapped, MPE zone points at X tracking mode, and channel labels point at Y/Z tracking. Scripts choosing IDs from `config list` could therefore target the wrong setting.

Align the enum with all 38 named system IDs through 41 in the preserved ROLI SDK. Remove misleading names and document their replacements, including the Python import compatibility change. Numeric CLI and API requests continue to send the supplied ID unchanged. The docs distinguish hardware brightness (SDK range 0 to 100) from the daemon's frame brightness (0 to 255).

Independent review matched every enum entry against `roli_BlockConfigId.h` and checked the brightness metadata. The full Python gate passes with 518 tests, Ruff, and ty; documentation lint/build also passes. No device settings were written. SDK declarations establish ID meanings, not availability or ranges on every firmware/program.
